### PR TITLE
HC-100: structured diagnostics (LSP-shaped)

### DIFF
--- a/Sources/Hypercode/Diagnostics/Diagnostic.swift
+++ b/Sources/Hypercode/Diagnostics/Diagnostic.swift
@@ -1,0 +1,93 @@
+/// A source position: 1-based line and column (the human / editor convention).
+public struct SourcePosition: Equatable, Sendable {
+    public let line: Int
+    public let column: Int
+
+    public init(line: Int, column: Int) {
+        self.line = line
+        self.column = column
+    }
+}
+
+/// A source range. For a point diagnostic, `start == end`.
+public struct SourceRange: Equatable, Sendable {
+    public let start: SourcePosition
+    public let end: SourcePosition
+
+    public init(start: SourcePosition, end: SourcePosition) {
+        self.start = start
+        self.end = end
+    }
+
+    public init(_ position: SourcePosition) {
+        self.start = position
+        self.end = position
+    }
+}
+
+/// Diagnostic severity. Raw values match LSP `DiagnosticSeverity`.
+public enum Severity: Int, Sendable {
+    case error = 1
+    case warning = 2
+    case information = 3
+    case hint = 4
+}
+
+/// A structured, machine-readable diagnostic — the unit consumed by tools and,
+/// via the LSP server, by editors.
+public struct Diagnostic: Equatable, Sendable {
+    public let severity: Severity
+    /// A stable diagnostic code, e.g. `HC1101`.
+    public let code: String
+    public let message: String
+    /// Source file path, when known.
+    public let file: String?
+    /// 1-based source range. `nil` when the diagnostic is not positional.
+    public let range: SourceRange?
+
+    public init(
+        severity: Severity,
+        code: String,
+        message: String,
+        file: String? = nil,
+        range: SourceRange? = nil
+    ) {
+        self.severity = severity
+        self.code = code
+        self.message = message
+        self.file = file
+        self.range = range
+    }
+}
+
+/// An error that can be presented as a ``Diagnostic``.
+public protocol DiagnosticConvertible: Error {
+    func diagnostic(file: String?) -> Diagnostic
+}
+
+extension LexError: DiagnosticConvertible {
+    public func diagnostic(file: String?) -> Diagnostic {
+        Diagnostic(
+            severity: .error, code: "HC1001", message: message, file: file,
+            range: SourceRange(SourcePosition(line: line, column: column))
+        )
+    }
+}
+
+extension ParseError: DiagnosticConvertible {
+    public func diagnostic(file: String?) -> Diagnostic {
+        Diagnostic(
+            severity: .error, code: "HC1101", message: message, file: file,
+            range: SourceRange(SourcePosition(line: line, column: column))
+        )
+    }
+}
+
+extension HCSError: DiagnosticConvertible {
+    public func diagnostic(file: String?) -> Diagnostic {
+        Diagnostic(
+            severity: .error, code: "HC2001", message: message, file: file,
+            range: SourceRange(SourcePosition(line: line, column: 1))
+        )
+    }
+}

--- a/Sources/Hypercode/Diagnostics/DiagnosticRenderer.swift
+++ b/Sources/Hypercode/Diagnostics/DiagnosticRenderer.swift
@@ -1,0 +1,82 @@
+/// Output format for diagnostics.
+public enum DiagnosticFormat: String, Sendable {
+    case text
+    case json
+}
+
+public extension Severity {
+    /// Short label used in human-readable output.
+    var label: String {
+        switch self {
+        case .error: return "error"
+        case .warning: return "warning"
+        case .information: return "note"
+        case .hint: return "hint"
+        }
+    }
+}
+
+public extension Diagnostic {
+    /// A single editor-parseable line: `file:line:col: error[HC1101]: message`.
+    func renderedText() -> String {
+        var location = ""
+        if let file { location += "\(file):" }
+        if let range {
+            location += "\(range.start.line):\(range.start.column): "
+        } else if !location.isEmpty {
+            location += " "
+        }
+        return "\(location)\(severity.label)[\(code)]: \(message)"
+    }
+}
+
+/// Renders diagnostics for the CLI and tools.
+public enum DiagnosticsRenderer {
+    public static func render(_ diagnostics: [Diagnostic], as format: DiagnosticFormat) -> String {
+        switch format {
+        case .text:
+            return diagnostics.map { $0.renderedText() }.joined(separator: "\n")
+        case .json:
+            return "[" + diagnostics.map(lspObject).joined(separator: ",") + "]"
+        }
+    }
+
+    /// One diagnostic as an LSP-shaped JSON object (positions are 0-based, per LSP).
+    private static func lspObject(_ d: Diagnostic) -> String {
+        var fields: [String] = []
+        if let range = d.range {
+            let start = "{\"line\":\(range.start.line - 1),\"character\":\(range.start.column - 1)}"
+            let end = "{\"line\":\(range.end.line - 1),\"character\":\(range.end.column - 1)}"
+            fields.append("\"range\":{\"start\":\(start),\"end\":\(end)}")
+        }
+        fields.append("\"severity\":\(d.severity.rawValue)")
+        fields.append("\"code\":\"\(escape(d.code))\"")
+        fields.append("\"source\":\"hypercode\"")
+        fields.append("\"message\":\"\(escape(d.message))\"")
+        if let file = d.file {
+            fields.append("\"file\":\"\(escape(file))\"")
+        }
+        return "{" + fields.joined(separator: ",") + "}"
+    }
+
+    private static func escape(_ string: String) -> String {
+        var out = ""
+        for scalar in string.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\t": out += "\\t"
+            case "\r": out += "\\r"
+            default:
+                if scalar.value < 0x20 {
+                    let hex = Array("0123456789abcdef")
+                    out += "\\u00\(hex[Int((scalar.value >> 4) & 0xF)])\(hex[Int(scalar.value & 0xF)])"
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out
+    }
+}

--- a/Sources/Hypercode/Validation/Validator.swift
+++ b/Sources/Hypercode/Validation/Validator.swift
@@ -1,24 +1,5 @@
 import SpecificationCore
 
-/// Severity of a validation ``Diagnostic``.
-public enum Severity: String, Sendable {
-    case error
-    case warning
-}
-
-/// A single validation finding.
-public struct Diagnostic: Equatable, Sendable {
-    public let severity: Severity
-    public let message: String
-    public let line: Int?
-
-    public init(severity: Severity, message: String, line: Int? = nil) {
-        self.severity = severity
-        self.message = message
-        self.line = line
-    }
-}
-
 /// Semantic validation of a `.hc` document and (optionally) a `.hcs` sheet
 /// against it. Syntactic validity is already guaranteed by the parser/reader;
 /// these checks catch document-level mistakes.
@@ -37,8 +18,9 @@ public struct Validator {
                         diagnostics.append(
                             Diagnostic(
                                 severity: .error,
+                                code: "HC3001",
                                 message: "duplicate id '#\(id)' (first defined at line \(firstLine))",
-                                line: node.line
+                                range: SourceRange(SourcePosition(line: node.line, column: 1))
                             )
                         )
                     } else {
@@ -58,7 +40,7 @@ public struct Validator {
         sheet.rules.compactMap { rule in
             anyNode(forest, ancestors: [], matches: selectorSpec(rule.selector))
                 ? nil
-                : Diagnostic(severity: .warning, message: "selector '\(rule.selector)' matches no node", line: rule.line)
+                : Diagnostic(severity: .warning, code: "HC3002", message: "selector '\(rule.selector)' matches no node", range: SourceRange(SourcePosition(line: rule.line, column: 1)))
         }
     }
 

--- a/Sources/HypercodeCLI/main.swift
+++ b/Sources/HypercodeCLI/main.swift
@@ -93,17 +93,20 @@ func runValidate(_ args: [String]) throws {
 
     guard let hcPath else { fail("error: validate needs a .hc file\n\n\(usage)", code: 64) }
 
-    let forest = try Parser(source: readSource(hcPath)).parse()
-    let validator = Validator()
-    var diagnostics = validator.validate(forest)
-    if let hcsPath {
-        let sheet = try CascadeSheetReader().read(readSource(hcsPath))
-        diagnostics += validator.validate(sheet, against: forest)
+    func tagged(_ diagnostics: [Diagnostic], file: String) -> [Diagnostic] {
+        diagnostics.map {
+            Diagnostic(severity: $0.severity, code: $0.code, message: $0.message,
+                       file: $0.file ?? file, range: $0.range)
+        }
     }
 
-    let located = diagnostics.map {
-        Diagnostic(severity: $0.severity, code: $0.code, message: $0.message,
-                   file: $0.file ?? hcPath, range: $0.range)
+    let forest = try Parser(source: readSource(hcPath)).parse()
+    let validator = Validator()
+    // .hc diagnostics point at the .hc file; .hcs diagnostics at the .hcs file.
+    var located = tagged(validator.validate(forest), file: hcPath)
+    if let hcsPath {
+        let sheet = try CascadeSheetReader().read(readSource(hcsPath))
+        located += tagged(validator.validate(sheet, against: forest), file: hcsPath)
     }
     switch diagnosticsFormat {
     case .json:

--- a/Sources/HypercodeCLI/main.swift
+++ b/Sources/HypercodeCLI/main.swift
@@ -7,7 +7,12 @@ usage:
   hypercode validate <file.hc> [--hcs <file.hcs>]
   hypercode resolve  <file.hc> --hcs <file.hcs> [--ctx key=value]...
   hypercode emit     <file.hc> [--hcs <file.hcs>] [--ctx key=value]... [--format json|yaml]
+
+global: [--diagnostics text|json]
 """
+
+var diagnosticsFormat: DiagnosticFormat = .text
+var currentInputFile: String?
 
 func fail(_ message: String, code: Int32 = 1) -> Never {
     FileHandle.standardError.write(Data((message + "\n").utf8))
@@ -15,6 +20,7 @@ func fail(_ message: String, code: Int32 = 1) -> Never {
 }
 
 func readSource(_ path: String) -> String {
+    currentInputFile = path
     guard
         let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
         let text = String(data: data, encoding: .utf8)
@@ -95,15 +101,17 @@ func runValidate(_ args: [String]) throws {
         diagnostics += validator.validate(sheet, against: forest)
     }
 
-    guard !diagnostics.isEmpty else {
-        print("ok: no issues found")
-        return
+    let located = diagnostics.map {
+        Diagnostic(severity: $0.severity, code: $0.code, message: $0.message,
+                   file: $0.file ?? hcPath, range: $0.range)
     }
-    for diagnostic in diagnostics {
-        let location = diagnostic.line.map { "line \($0): " } ?? ""
-        print("\(diagnostic.severity.rawValue): \(location)\(diagnostic.message)")
+    switch diagnosticsFormat {
+    case .json:
+        print(DiagnosticsRenderer.render(located, as: .json))
+    case .text:
+        print(located.isEmpty ? "ok: no issues found" : DiagnosticsRenderer.render(located, as: .text))
     }
-    if diagnostics.contains(where: { $0.severity == .error }) {
+    if located.contains(where: { $0.severity == .error }) {
         exit(1)
     }
 }
@@ -151,7 +159,26 @@ func runEmit(_ args: [String]) throws {
     print(Emitter().emit(resolved, as: format), terminator: "")
 }
 
-let arguments = Array(CommandLine.arguments.dropFirst())
+// Pull the global `--diagnostics <format>` flag out of the argument list.
+let arguments: [String] = {
+    let raw = Array(CommandLine.arguments.dropFirst())
+    var rest: [String] = []
+    var index = 0
+    while index < raw.count {
+        if raw[index] == "--diagnostics" {
+            index += 1
+            guard index < raw.count, let format = DiagnosticFormat(rawValue: raw[index]) else {
+                fail("error: --diagnostics expects text|json")
+            }
+            diagnosticsFormat = format
+        } else {
+            rest.append(raw[index])
+        }
+        index += 1
+    }
+    return rest
+}()
+
 guard let command = arguments.first else {
     fail(usage, code: 64)
 }
@@ -173,6 +200,10 @@ do {
         // Backwards-compatible shorthand: `hypercode <file.hc>`.
         try runParse(command)
     }
+} catch let error as DiagnosticConvertible {
+    let rendered = DiagnosticsRenderer.render([error.diagnostic(file: currentInputFile)], as: diagnosticsFormat)
+    FileHandle.standardError.write(Data((rendered + "\n").utf8))
+    exit(1)
 } catch {
     fail("\(error)")
 }

--- a/Tests/HypercodeTests/DiagnosticsTests.swift
+++ b/Tests/HypercodeTests/DiagnosticsTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import Hypercode
+
+final class DiagnosticsTests: XCTestCase {
+    func testParseErrorBecomesDiagnostic() {
+        do {
+            _ = try Parser(source: ".bad\n").parse()
+            XCTFail("expected a parse error")
+        } catch let error as DiagnosticConvertible {
+            let d = error.diagnostic(file: "app.hc")
+            XCTAssertEqual(d.severity, .error)
+            XCTAssertEqual(d.code, "HC1101")
+            XCTAssertEqual(d.file, "app.hc")
+            XCTAssertNotNil(d.range)
+        } catch {
+            XCTFail("expected DiagnosticConvertible, got \(error)")
+        }
+    }
+
+    func testLexErrorBecomesDiagnostic() {
+        XCTAssertThrowsError(try Lexer("123Bad\n").tokenize()) { error in
+            guard let convertible = error as? DiagnosticConvertible else {
+                return XCTFail("expected DiagnosticConvertible")
+            }
+            XCTAssertEqual(convertible.diagnostic(file: nil).code, "HC1001")
+        }
+    }
+
+    func testTextRendering() {
+        let d = Diagnostic(
+            severity: .error, code: "HC1101", message: "boom",
+            file: "app.hc", range: SourceRange(SourcePosition(line: 3, column: 5))
+        )
+        XCTAssertEqual(d.renderedText(), "app.hc:3:5: error[HC1101]: boom")
+    }
+
+    func testJSONRenderingIsLSPShaped() {
+        let d = Diagnostic(
+            severity: .warning, code: "HC3002", message: "x",
+            file: "a.hcs", range: SourceRange(SourcePosition(line: 2, column: 4))
+        )
+        let json = DiagnosticsRenderer.render([d], as: .json)
+        XCTAssertTrue(json.contains("\"line\":1"))        // 0-based line
+        XCTAssertTrue(json.contains("\"character\":3"))   // 0-based column
+        XCTAssertTrue(json.contains("\"severity\":2"))    // LSP warning
+        XCTAssertTrue(json.contains("\"code\":\"HC3002\""))
+        XCTAssertTrue(json.contains("\"source\":\"hypercode\""))
+    }
+
+    func testValidatorDiagnosticsAreCoded() throws {
+        let forest = try Parser(source: "A#x\nB#x\n").parse()
+        let diagnostics = Validator().validate(forest)
+        XCTAssertEqual(diagnostics.first?.code, "HC3001")
+        XCTAssertEqual(diagnostics.first?.severity, .error)
+    }
+}

--- a/workplan.md
+++ b/workplan.md
@@ -77,6 +77,14 @@ cascade sheets (`.hcs`). Companion to the [RFC](RFC/Hypercode.md) and the
 - [ ] HC-062 Refactor Hyperprompt to depend on Hypercode's grammar-core (after it stabilizes)
 - [ ] HC-063 Refactor Ontology's Hypercode import path onto the shared grammar-core
 
+## M7 — Diagnostics & LSP (VS Code)
+- [x] HC-100 Structured diagnostics: unified `Diagnostic` (severity, code, source range), LSP-shaped JSON + editor-parseable text, CLI `--diagnostics text|json` — `Sources/Hypercode/Diagnostics/`
+- [ ] HC-101 Minimal Swift LSP server (`hypercode lsp`): JSON-RPC over stdio, document sync, `publishDiagnostics`
+- [ ] HC-102 Thin VS Code extension on `vscode-languageclient` that launches the server
+- [ ] HC-103 Hover / go-to-definition (later, same server)
+
+*(Aim straight for LSP — the standard for VS Code & editor-agnostic. Hyperprompt's custom CLI+JSON-RPC was a documented MVP stopgap; see its ADR-001.)*
+
 ## Cross-cutting
 - [x] HC-090 Swift CI workflow (build + test) — `.github/workflows/swift.yml`
 - [x] HC-091 Repo layout documented (root Swift package) — `DOCS/Architecture.md`


### PR DESCRIPTION
## Summary

Foundation for VS Code / LSP support: every lexer / parser / HCS / validation
finding becomes one structured **`Diagnostic`** (severity matching LSP, a stable
**code**, a source **range**), renderable as editor-parseable text or
**LSP-shaped JSON**.

Step 1 of M7 (Diagnostics & LSP). It feeds the upcoming `hypercode lsp` server
(HC-101) and a thin VS Code extension (HC-102).

### What's here
- `Sources/Hypercode/Diagnostics/` — `Diagnostic`, `Severity` (LSP values),
  `SourcePosition` / `SourceRange`, `DiagnosticConvertible` (LexError / ParseError
  / HCSError conform), and a renderer (text + LSP JSON, 0-based positions).
- Codes: `HC1001` lex, `HC1101` parse, `HC2001` hcs, `HC3001` / `HC3002` validation.
- CLI: a global `--diagnostics text|json` flag; `validate` and the error path emit
  through it.

### Demo
```
$ hypercode validate dup.hc --diagnostics json
[{"range":{"start":{"line":1,"character":0},"end":{"line":1,"character":0}},"severity":1,"code":"HC3001","source":"hypercode","message":"duplicate id '#x' (first defined at line 1)","file":"dup.hc"}]
```

### Verification
43 tests green (5 new). No behavior change to parse / resolve / emit.

### Aim
LSP directly (the standard for VS Code, editor-agnostic) — not a custom RPC.
Hyperprompt's CLI+JSON-RPC was a documented MVP stopgap (its ADR-001 plans LSP
as the long-term).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
