### PR TITLE
HC-101: minimal LSP server (hypercode lsp)

### DIFF
--- a/Sources/Hypercode/Diagnostics/DocumentDiagnostics.swift
+++ b/Sources/Hypercode/Diagnostics/DocumentDiagnostics.swift
@@ -1,0 +1,29 @@
+/// The kind of document being diagnosed.
+public enum DocumentKind: Equatable, Sendable {
+    case hypercode      // .hc
+    case cascadeSheet   // .hcs
+
+    /// Infer the kind from a path or URI by extension (defaults to `.hypercode`).
+    public init(path: String) {
+        self = path.hasSuffix(".hcs") ? .cascadeSheet : .hypercode
+    }
+}
+
+/// Computes diagnostics for a single document's text — the shared core of the
+/// LSP server's live diagnostics and of `hypercode validate`.
+public func diagnostics(for kind: DocumentKind, text: String, file: String? = nil) -> [Diagnostic] {
+    do {
+        switch kind {
+        case .cascadeSheet:
+            _ = try CascadeSheetReader().read(text)
+            return []
+        case .hypercode:
+            let forest = try Parser(source: text).parse()
+            return Validator().validate(forest)
+        }
+    } catch let error as DiagnosticConvertible {
+        return [error.diagnostic(file: file)]
+    } catch {
+        return []
+    }
+}

--- a/Sources/Hypercode/Diagnostics/DocumentDiagnostics.swift
+++ b/Sources/Hypercode/Diagnostics/DocumentDiagnostics.swift
@@ -5,7 +5,7 @@ public enum DocumentKind: Equatable, Sendable {
 
     /// Infer the kind from a path or URI by extension (defaults to `.hypercode`).
     public init(path: String) {
-        self = path.hasSuffix(".hcs") ? .cascadeSheet : .hypercode
+        self = path.lowercased().hasSuffix(".hcs") ? .cascadeSheet : .hypercode
     }
 }
 
@@ -24,6 +24,8 @@ public func diagnostics(for kind: DocumentKind, text: String, file: String? = ni
     } catch let error as DiagnosticConvertible {
         return [error.diagnostic(file: file)]
     } catch {
-        return []
+        // Surface, don't silently report the document as clean.
+        return [Diagnostic(severity: .error, code: "HC9000",
+                           message: "internal error: \(error)", file: file)]
     }
 }

--- a/Sources/HypercodeCLI/LSPServer.swift
+++ b/Sources/HypercodeCLI/LSPServer.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Hypercode
+
+/// A minimal Language Server Protocol server over stdio (JSON-RPC 2.0).
+///
+/// Scope (HC-101): document lifecycle + live diagnostics. On open/change/save it
+/// parses (`.hc`) or reads (`.hcs`) the document text and publishes diagnostics.
+/// Hover / go-to-definition come later, on the same server.
+final class LSPServer {
+    private var documents: [String: String] = [:]   // uri -> text
+    private var buffer = Data()
+
+    func run() {
+        while let message = readMessage() {
+            handle(message)
+        }
+    }
+
+    // MARK: - Dispatch
+
+    private func handle(_ message: [String: Any]) {
+        let method = message["method"] as? String
+        let id = message["id"]
+
+        switch method {
+        case "initialize":
+            respond(id: id, result: [
+                "capabilities": ["textDocumentSync": 1],   // 1 = Full
+                "serverInfo": ["name": "hypercode", "version": "0.4.0"],
+            ])
+        case "initialized":
+            break
+        case "textDocument/didOpen":
+            if let document = (message["params"] as? [String: Any])?["textDocument"] as? [String: Any],
+               let uri = document["uri"] as? String,
+               let text = document["text"] as? String {
+                documents[uri] = text
+                publishDiagnostics(uri: uri, text: text)
+            }
+        case "textDocument/didChange":
+            if let params = message["params"] as? [String: Any],
+               let uri = (params["textDocument"] as? [String: Any])?["uri"] as? String,
+               let changes = params["contentChanges"] as? [[String: Any]],
+               let text = changes.last?["text"] as? String {
+                documents[uri] = text
+                publishDiagnostics(uri: uri, text: text)
+            }
+        case "textDocument/didSave":
+            if let uri = ((message["params"] as? [String: Any])?["textDocument"] as? [String: Any])?["uri"] as? String,
+               let text = documents[uri] {
+                publishDiagnostics(uri: uri, text: text)
+            }
+        case "textDocument/didClose":
+            if let uri = ((message["params"] as? [String: Any])?["textDocument"] as? [String: Any])?["uri"] as? String {
+                documents[uri] = nil
+                send(["jsonrpc": "2.0", "method": "textDocument/publishDiagnostics",
+                      "params": ["uri": uri, "diagnostics": []]])
+            }
+        case "shutdown":
+            respond(id: id, result: NSNull())
+        case "exit":
+            exit(0)
+        default:
+            break
+        }
+    }
+
+    // MARK: - Diagnostics
+
+    private func publishDiagnostics(uri: String, text: String) {
+        let computed = Hypercode.diagnostics(for: DocumentKind(path: uri), text: text).map(Self.lspObject)
+        send(["jsonrpc": "2.0", "method": "textDocument/publishDiagnostics",
+              "params": ["uri": uri, "diagnostics": computed]])
+    }
+
+    static func lspObject(_ d: Diagnostic) -> [String: Any] {
+        let range = d.range ?? SourceRange(SourcePosition(line: 1, column: 1))
+        return [
+            "range": [
+                "start": ["line": range.start.line - 1, "character": range.start.column - 1],
+                "end": ["line": range.end.line - 1, "character": range.end.column - 1],
+            ],
+            "severity": d.severity.rawValue,
+            "code": d.code,
+            "source": "hypercode",
+            "message": d.message,
+        ]
+    }
+
+    // MARK: - JSON-RPC framing (Content-Length over stdio)
+
+    private func respond(id: Any?, result: Any) {
+        var message: [String: Any] = ["jsonrpc": "2.0", "result": result]
+        if let id { message["id"] = id }
+        send(message)
+    }
+
+    private func send(_ object: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: object) else { return }
+        var out = Data("Content-Length: \(data.count)\r\n\r\n".utf8)
+        out.append(data)
+        FileHandle.standardOutput.write(out)
+    }
+
+    private func readMessage() -> [String: Any]? {
+        while true {
+            if let body = nextBody() {
+                if let object = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any] {
+                    return object
+                }
+                continue // malformed frame; skip
+            }
+            let chunk = FileHandle.standardInput.availableData
+            if chunk.isEmpty { return nil } // EOF
+            buffer.append(chunk)
+        }
+    }
+
+    /// Extracts one complete message body from the buffer, or `nil` if more
+    /// input is needed.
+    private func nextBody() -> Data? {
+        guard let headerRange = buffer.range(of: Data("\r\n\r\n".utf8)) else { return nil }
+
+        let header = String(decoding: buffer[buffer.startIndex..<headerRange.lowerBound], as: UTF8.self)
+        var contentLength = 0
+        for line in header.split(whereSeparator: { $0 == "\r" || $0 == "\n" }) {
+            if line.lowercased().hasPrefix("content-length:") {
+                contentLength = Int(line.dropFirst("content-length:".count).trimmingCharacters(in: .whitespaces)) ?? 0
+            }
+        }
+
+        let bodyStart = headerRange.upperBound
+        guard buffer.distance(from: bodyStart, to: buffer.endIndex) >= contentLength else { return nil }
+        let bodyEnd = buffer.index(bodyStart, offsetBy: contentLength)
+        let body = Data(buffer[bodyStart..<bodyEnd])
+        buffer = Data(buffer[bodyEnd...])   // re-base the remaining buffer
+        return body
+    }
+}

--- a/Sources/HypercodeCLI/LSPServer.swift
+++ b/Sources/HypercodeCLI/LSPServer.swift
@@ -25,7 +25,10 @@ final class LSPServer {
         switch method {
         case "initialize":
             respond(id: id, result: [
-                "capabilities": ["textDocumentSync": 1],   // 1 = Full
+                "capabilities": [
+                    // Object form so clients enable open/close/save, not just change.
+                    "textDocumentSync": ["openClose": true, "change": 1, "save": true],
+                ],
                 "serverInfo": ["name": "hypercode", "version": "0.4.0"],
             ])
         case "initialized":

--- a/Sources/HypercodeCLI/main.swift
+++ b/Sources/HypercodeCLI/main.swift
@@ -7,6 +7,7 @@ usage:
   hypercode validate <file.hc> [--hcs <file.hcs>]
   hypercode resolve  <file.hc> --hcs <file.hcs> [--ctx key=value]...
   hypercode emit     <file.hc> [--hcs <file.hcs>] [--ctx key=value]... [--format json|yaml]
+  hypercode lsp                                                    # language server (LSP over stdio)
 
 global: [--diagnostics text|json]
 """
@@ -196,6 +197,8 @@ do {
         try runValidate(Array(arguments.dropFirst()))
     case "emit":
         try runEmit(Array(arguments.dropFirst()))
+    case "lsp":
+        LSPServer().run()
     case "parse":
         guard arguments.count >= 2 else { fail(usage, code: 64) }
         try runParse(arguments[1])

--- a/Tests/HypercodeTests/DocumentDiagnosticsTests.swift
+++ b/Tests/HypercodeTests/DocumentDiagnosticsTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import Hypercode
+
+final class DocumentDiagnosticsTests: XCTestCase {
+    func testKindFromPath() {
+        XCTAssertEqual(DocumentKind(path: "a.hcs"), .cascadeSheet)
+        XCTAssertEqual(DocumentKind(path: "a.hc"), .hypercode)
+        XCTAssertEqual(DocumentKind(path: "noext"), .hypercode)
+    }
+
+    func testHypercodeDocumentParseError() {
+        let result = diagnostics(for: .hypercode, text: ".bad\n")
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.code, "HC1101")
+    }
+
+    func testHypercodeDocumentValidationWarning() {
+        let result = diagnostics(for: .hypercode, text: "A#x\nB#x\n")
+        XCTAssertEqual(result.first?.code, "HC3001")
+    }
+
+    func testCascadeSheetDocumentError() {
+        let result = diagnostics(for: .cascadeSheet, text: "123Bad:\n  x: 1\n")
+        XCTAssertEqual(result.first?.code, "HC2001")
+    }
+
+    func testCleanDocumentHasNoDiagnostics() {
+        XCTAssertTrue(diagnostics(for: .hypercode, text: "App\n  Button\n").isEmpty)
+    }
+}

--- a/Tests/HypercodeTests/DocumentDiagnosticsTests.swift
+++ b/Tests/HypercodeTests/DocumentDiagnosticsTests.swift
@@ -14,7 +14,7 @@ final class DocumentDiagnosticsTests: XCTestCase {
         XCTAssertEqual(result.first?.code, "HC1101")
     }
 
-    func testHypercodeDocumentValidationWarning() {
+    func testHypercodeDocumentDuplicateId() {
         let result = diagnostics(for: .hypercode, text: "A#x\nB#x\n")
         XCTAssertEqual(result.first?.code, "HC3001")
     }

--- a/workplan.md
+++ b/workplan.md
@@ -79,7 +79,7 @@ cascade sheets (`.hcs`). Companion to the [RFC](RFC/Hypercode.md) and the
 
 ## M7 — Diagnostics & LSP (VS Code)
 - [x] HC-100 Structured diagnostics: unified `Diagnostic` (severity, code, source range), LSP-shaped JSON + editor-parseable text, CLI `--diagnostics text|json` — `Sources/Hypercode/Diagnostics/`
-- [ ] HC-101 Minimal Swift LSP server (`hypercode lsp`): JSON-RPC over stdio, document sync, `publishDiagnostics`
+- [x] HC-101 Minimal Swift LSP server (`hypercode lsp`): JSON-RPC over stdio, `initialize`, document sync (didOpen/didChange/didSave/didClose), live `publishDiagnostics` — `Sources/HypercodeCLI/LSPServer.swift` + shared `diagnostics(for:text:)` in the library
 - [ ] HC-102 Thin VS Code extension on `vscode-languageclient` that launches the server
 - [ ] HC-103 Hover / go-to-definition (later, same server)
 


### PR DESCRIPTION
## Summary

A minimal **Language Server** over stdio — VS Code (and any LSP editor) talks to
`hypercode lsp` directly via `vscode-languageclient`. The standard path, not a
custom RPC. Builds on HC-100's structured diagnostics.

### What's here
- `Sources/HypercodeCLI/LSPServer.swift` — JSON-RPC 2.0 over stdio: `initialize`
  handshake, full document sync (`didOpen` / `didChange` / `didSave` / `didClose`),
  and live `textDocument/publishDiagnostics`.
- `hypercode lsp` CLI subcommand.
- Shared `diagnostics(for:text:)` library function (`.hc` parse + validate, `.hcs`
  read) — the LSP server's per-document core, unit-tested. (`validate` shares the
  same `Parser` / `Validator` building blocks but adds cross-file selector checks,
  so it does not call this single-document wrapper.)

### Verification
48 tests green. Plus a stdio smoke test: open a clean `.hc` → `diagnostics: []`;
change to a duplicate-id `.hc` → `publishDiagnostics` with `HC3001`.

### Next
HC-102: a thin VS Code extension (`vscode-languageclient`) that launches
`hypercode lsp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
