### PR TITLE
docs: VS Code extension release roadmap

### DIFF
--- a/DOCS/Architecture.md
+++ b/DOCS/Architecture.md
@@ -29,3 +29,8 @@ Consumers (Ontology, Hyperprompt, …) depend on Hypercode, never the reverse. T
 integration contract is the resolved-graph IR (`Schema/`), not the Swift
 API: a consumer reads the emitted IR (or links the library) and projects it to
 its own target. See [Backends.md](Backends.md) and [Dialects.md](Dialects.md).
+
+## Releasing
+
+How the CLI/library and the VS Code extension get shipped (VSIX, Marketplace,
+CI automation) is documented in [Release.md](Release.md).

--- a/DOCS/Release.md
+++ b/DOCS/Release.md
@@ -1,0 +1,93 @@
+# Hypercode — Release & Distribution Roadmap
+
+How the two shipped artifacts get released: the Swift `hypercode` CLI/library and
+the VS Code extension that drives it. The extension is a thin LSP client — it
+needs the CLI on `PATH` — so the two ship together.
+
+## Artifacts
+
+| Artifact | Source | Consumed as |
+|---|---|---|
+| `hypercode` CLI + `Hypercode` library | root SwiftPM package | `swift build`, or `.package(url: …, from: …)` |
+| Hypercode VS Code extension | `editors/vscode/` | `.vsix`, or the VS Code Marketplace |
+
+## VS Code extension
+
+The extension (`publisher: 0al-spec`, id `hypercode`) is a thin
+`vscode-languageclient` that spawns `hypercode lsp`. Three release tiers, from
+local to public.
+
+### Tier 1 — VSIX (local install / GitHub Release asset)
+
+No account required. Produces a portable `.vsix` anyone can install.
+
+```bash
+cd editors/vscode
+npm install
+npm install -g @vscode/vsce      # one-time
+vsce package                     # → hypercode-<version>.vsix
+```
+
+Install it:
+
+```bash
+code --install-extension hypercode-<version>.vsix
+```
+
+The `.vsix` can be attached to a GitHub Release as a download.
+
+> Note: `.vscodeignore` intentionally does **not** exclude `node_modules` —
+> `vsce` resolves production vs dev dependencies itself, and excluding the folder
+> would strip `vscode-languageclient` from the package.
+
+### Tier 2 — VS Code Marketplace (public)
+
+1. **Create the publisher** `0al-spec` at
+   <https://marketplace.visualstudio.com/manage> (must match `package.json`'s
+   `publisher`).
+2. **Mint an Azure DevOps PAT** at <https://dev.azure.com> →
+   User Settings → Personal access tokens, scope **Marketplace → Manage**.
+3. **Publish:**
+
+   ```bash
+   vsce login 0al-spec     # paste the PAT
+   vsce publish            # or: vsce publish --pat <TOKEN>
+   ```
+
+`vsce publish [major|minor|patch]` bumps `package.json` and tags in one step.
+
+### Tier 3 — CI automation (recommended)
+
+A workflow triggered on a `vscode/v*` tag:
+
+1. `npm ci && vsce package` → upload the `.vsix` as a GitHub Release asset.
+2. `vsce publish` using a `VSCE_PAT` repository secret.
+
+Release then reduces to:
+
+```bash
+git tag vscode/v0.1.0 && git push --tags
+```
+
+**Prerequisites for Tier 2/3** (one-time, manual):
+- Register the `0al-spec` publisher on the Marketplace site.
+- Add a `VSCE_PAT` secret under repo Settings → Secrets and variables → Actions.
+
+## Swift CLI / library
+
+The library is consumed directly by SwiftPM tag:
+
+```swift
+.package(url: "https://github.com/0al-spec/Hypercode", from: "0.4.0")
+```
+
+A release is a semver git tag on `main`. The VS Code extension's `serverInfo`
+version (currently `0.4.0`, see `LSPServer.swift`) should track the CLI release
+it was tested against.
+
+## Versioning
+
+- **CLI / library** — semver git tags (`0.4.0`, …); the IR carries its own
+  schema version (`hypercode.ir/v1`), independent of the package version.
+- **Extension** — `editors/vscode/package.json` `version`, released under
+  `vscode/v*` tags so it can move independently of the CLI.

--- a/DOCS/Release.md
+++ b/DOCS/Release.md
@@ -2,7 +2,8 @@
 
 How the two shipped artifacts get released: the Swift `hypercode` CLI/library and
 the VS Code extension that drives it. The extension is a thin LSP client — it
-needs the CLI on `PATH` — so the two ship together.
+needs the CLI installed and discoverable (on `PATH`, or via the
+`hypercode.serverPath` setting) — so the two ship together.
 
 ## Artifacts
 
@@ -13,9 +14,10 @@ needs the CLI on `PATH` — so the two ship together.
 
 ## VS Code extension
 
-The extension (`publisher: 0al-spec`, id `hypercode`) is a thin
-`vscode-languageclient` that spawns `hypercode lsp`. Three release tiers, from
-local to public.
+The extension is a thin `vscode-languageclient` that spawns `hypercode lsp`. Its
+`package.json` declares `publisher: 0al-spec` and `name: hypercode`, so the full
+Marketplace identifier is `0al-spec.hypercode`. Three release tiers, from local
+to public.
 
 ### Tier 1 — VSIX (local install / GitHub Release asset)
 
@@ -63,10 +65,18 @@ A workflow triggered on a `vscode/v*` tag:
 1. `npm ci && vsce package` → upload the `.vsix` as a GitHub Release asset.
 2. `vsce publish` using a `VSCE_PAT` repository secret.
 
-Release then reduces to:
+> ⚠️ **The version lives in `package.json`, not the tag.** `vsce package` /
+> `vsce publish` read `editors/vscode/package.json` `version` — the `vscode/v*`
+> tag name is *not* consulted. So the tag alone is not enough: a new release must
+> first bump and commit `package.json` (e.g. `vsce publish minor`, which bumps,
+> commits and tags in one step), or the workflow must derive the version from the
+> tag and write it into `package.json` before packaging. Otherwise a `vscode/v0.2.0`
+> tag would still publish `0.1.0`, and Marketplace would reject it as a duplicate.
+
+Release then reduces to (version already bumped & committed):
 
 ```bash
-git tag vscode/v0.1.0 && git push --tags
+git tag vscode/v0.2.0 && git push --tags
 ```
 
 **Prerequisites for Tier 2/3** (one-time, manual):

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -35,4 +35,6 @@ npm run compile
 ## Release
 
 Packaging (`.vsix`), Marketplace publishing, and CI automation are documented in
-[`DOCS/Release.md`](../../DOCS/Release.md).
+[`DOCS/Release.md`](https://github.com/0al-spec/Hypercode/blob/main/DOCS/Release.md)
+(the relative path is `../../DOCS/Release.md` in the repo; an absolute URL is used
+here so the link also resolves in the packaged Marketplace README).

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -31,3 +31,8 @@ npm run compile
 ## Settings
 
 - `hypercode.serverPath` — path to the `hypercode` executable (default: `hypercode`).
+
+## Release
+
+Packaging (`.vsix`), Marketplace publishing, and CI automation are documented in
+[`DOCS/Release.md`](../../DOCS/Release.md).


### PR DESCRIPTION
## What

Adds `DOCS/Release.md` — the release & distribution roadmap for both shipped artifacts:

- **VS Code extension** — three tiers:
  1. **VSIX** (`vsce package`) for local install / GitHub Release assets
  2. **Marketplace** (`0al-spec` publisher + Azure DevOps PAT → `vsce publish`)
  3. **CI automation** on a `vscode/v*` tag (package → upload asset → publish via `VSCE_PAT` secret)
- **Swift CLI / library** — semver git tags, SwiftPM consumption, IR schema versioning.

Cross-linked from `DOCS/Architecture.md` ("Releasing" section) and the extension `README.md`.

## Why

The extension and CLI were build- and CI-verified but had no documented release path. This captures the manual prerequisites (publisher registration, `VSCE_PAT` secret) and the eventual `git tag vscode/v*` flow.

## Notes

Docs only — no code changes. The CI workflow described in Tier 3 is intentionally **not** added here; it depends on the manual `VSCE_PAT` / publisher setup that only the maintainer can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)