### PR TITLE
docs: RFC v0.1.1 — §9 Novelty and Prior Art

### DIFF
--- a/DOCS/Positioning.md
+++ b/DOCS/Positioning.md
@@ -1,0 +1,113 @@
+# Hypercode — Positioning
+
+The one-sentence formula:
+
+> **Hypercode is a formal, provenance-preserving, context-resolved specification
+> layer between human-reviewed architectural intent and deterministic or
+> AI-assisted code generation.**
+
+This document fixes the market positioning, the phrasing discipline around the
+novelty claim, and the validation/adoption strategy. The full prior-art
+analysis lives in [RFC §9](../RFC/Hypercode.md).
+
+## The pitch, by audience
+
+- **README hook:** *CSS for application structure* — selectors, cascade, and
+  provenance over a stable program topology, with the DevTools built in
+  (`explain`).
+- **Engineering:** one structure, many contexts. Swap `--ctx` to get a
+  different build without touching the structure, and every resolved value
+  answers "why am I here?" with a selector and a source line.
+- **Enterprise:** *review compression*. Humans approve a small, formally
+  resolved spec diff; machines expand it into code and validate the expansion;
+  every generated behavior traces back to its source selector.
+
+## The novelty claim (phrasing discipline)
+
+The claim is a **combination**, stated falsifiably:
+
+> We have not found a mainstream specification or tooling stack that combines:
+> a stable addressable topology, CSS-like selector cascade, deterministic
+> context resolution, property-level provenance, monotonic selector contracts,
+> and a resolved-IR diff for incremental AI-assisted code generation.
+
+Never claim "nothing like this exists". Every individual ingredient has mature
+prior art; the prior-art map in RFC §9.3 names it deliberately, including the
+two closest relatives: **OAM/KubeVela** (structural) and **software product
+lines** (academic).
+
+## What Hypercode is not
+
+- **Not a typed configuration language** (CUE, Dhall, Nickel, Pkl, KCL,
+  Jsonnet) — they validate and generate configuration *data*; Hypercode's
+  subject is an addressable *topology* plus rules over it.
+- **Not model-driven architecture** — `.hc` is deliberately incomplete: a
+  skeleton plus context policies, not a complete model. The term *"executable
+  architecture" is deprecated* in Hypercode materials; it imports MDA/TOSCA
+  expectations the design explicitly avoids.
+- **Not a Markdown SDD format** (Spec Kit, Kiro, AGENTS.md) — Hypercode sits
+  *underneath* such documents as the part that resolves deterministically and
+  diffs semantically.
+- **Not an interface contract** (OpenAPI, AsyncAPI, GraphQL) — nodes
+  *reference* external contracts (`api_contract: "openapi/users.yaml"`);
+  generating or owning route/payload schemas is a non-goal.
+- **Not a runtime feature-flag system** (OpenFeature, LaunchDarkly) — see the
+  layer answers below.
+
+## Layer answers (for common challenges)
+
+- **"Why not OpenFeature + CUE?"** OpenFeature decides dynamic flag values at
+  runtime. CUE validates and generates configuration data. Hypercode resolves
+  an addressable application topology into a provenance-preserving IR for
+  explain, diff, validation, and code generation. Different layers; they
+  compose.
+- **"Isn't this OAM/KubeVela?"** OAM separates components from traits and
+  policies for *delivery* on Kubernetes. It has no specificity cascade, no
+  property-level provenance, and no codegen-oriented IR.
+- **"Isn't this Spec Kit?"** Same thesis — the spec is the durable artifact,
+  code is regenerated output — different layer: Markdown guides agents;
+  Hypercode is the formal substrate underneath it.
+- **"Cascade is what CUE banned."** See the safety lock below.
+
+## The safety lock: asymmetric cascade
+
+The architectural rule that makes the cascade defensible (normative, RFC
+§9.4):
+
+> Values cascade. Contracts accumulate and narrow.
+> A more specific selector MAY override a value.
+> A more specific selector MUST NOT weaken an inherited contract.
+
+Hypercode cascades *behavior*, never *safety*. This combines CUE-like
+monotonic safety with CSS-like contextual value selection and DevTools-like
+provenance — and is the direct answer to the GCL/CUE override objection.
+
+## Validation strategy: one deep demo
+
+One honest comparison beats five shallow ones; every additional target invites
+"you strawmanned X". The target is **Kustomize** (largest audience, most
+visceral overlay-archaeology pain):
+
+- N tenants × M environments, side by side;
+- measured: duplicated structure, time to answer "why is this value here?"
+  (`explain` vs. overlay archaeology), precision of affected-module
+  regeneration (IR diff);
+- **must include Hypercode's own failure mode** — a specificity conflict —
+  and show `explain` resolving it. A demo that shows its warts is believed.
+
+## Adoption path
+
+1. **Dogfooding first:** Hyperprompt and Ontology consume the resolved IR
+   (dialects and backends stay consumer-side, per
+   [Dialects](Dialects.md) / [Backends](Backends.md)).
+2. The Kustomize demo for external audiences.
+3. Standalone adoption last — only after 1–2 produce evidence.
+
+## Vocabulary
+
+| Deprecated | Preferred |
+|---|---|
+| "executable architecture" | "context-resolved specification layer" |
+| "a new YAML" / "config language" | "topology + rules, resolved with provenance" |
+| "declarative DI" | "stable anchors for wiring, codegen, and validation" |
+| "AI writes the code from the spec" (alone) | "review compression: humans approve the spec diff, machines expand and validate it" |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ hypercode resolve Examples/service.hc --hcs Examples/service.hcs --ctx env=produ
 - [Conceptual overview](OVERVIEW.md)
 - [RFC — the paradigm](RFC/Hypercode.md)
 - Formal specs: [`.hc` syntax (BNF)](EBNF/Hypercode_Syntax.md) · [resolution semantics](EBNF/Hypercode_Resolution.md)
-- Architecture: [overview](DOCS/Architecture.md) · [backends & adapters](DOCS/Backends.md) · [core vs dialects](DOCS/Dialects.md)
+- Architecture: [overview](DOCS/Architecture.md) · [backends & adapters](DOCS/Backends.md) · [core vs dialects](DOCS/Dialects.md) · [positioning](DOCS/Positioning.md)
 - [Resolved-graph IR schema](Schema/hypercode-ir-v1.schema.json) — the cross-implementation contract
 - [Lean 4 cascade oracle](SPEC/lean/) — machine-checked agreement with the resolver
 - [Work plan](workplan.md) · [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md)

--- a/RFC/Hypercode.md
+++ b/RFC/Hypercode.md
@@ -2,9 +2,9 @@
 
 **Status:** Draft
 
-**Version:** 0.1
+**Version:** 0.2
 
-**Date:** July 8, 2025
+**Date:** June 10, 2026
 
 **Author:** Egor Merkushev
 
@@ -236,11 +236,67 @@ Hypercode and HCS are declarative and do not define runtime execution isolation 
 
 The specification assumes that the resolution and execution engine is trusted. No mechanisms are currently defined for verifying integrity of `.hcs` rules or controlling their provenance. Future versions may include digital signing or validation capabilities.
 
-## 9. Comparison to Existing Concepts
+## 9. Novelty and Prior Art
 
-*  **Dependency Injection (DI):** Hypercode can be seen as a form of declarative, externalized DI. Unlike traditional DI containers configured via XML or annotations, HCS provides a more expressive and dynamic configuration mechanism through selectors and @rules.
-*  **Templating Engines (e.g., Jinja, Handlebars):** While similar, templating engines typically generate static text or configuration files. Hypercode is concerned with generating and configuring a live, executable program graph.
-*  **Infrastructure as Code (IaC, e.g., Ansible, Terraform):** Hypercode shares the declarative philosophy of IaC tools but applies it to the application logic itself, rather than to the underlying infrastructure. It defines the application's runtime behavior, not just its deployment environment using HCS.
+### 9.1. The Claim
+
+No single ingredient of Hypercode is new. Selectors, cascading configuration, dependency graphs, code generation, and specification-driven development each have mature prior art. The claim is narrower, and deliberately falsifiable:
+
+> We have not found a mainstream specification or tooling stack that combines, in one format: (1) a stable, addressable application topology; (2) CSS-like selector rules over that topology; (3) deterministic cascade resolution with specificity and context rules; (4) first-class provenance for every resolved property; and (5) a versioned resolved IR designed for explanation, semantic diffing, validation, and incremental — including AI-assisted — code generation.
+
+Hypercode is therefore a new *combination* and a new *layer* — a context-resolved specification layer between human-reviewed architectural intent and deterministic or AI-assisted code generation — not a wholly new idea.
+
+### 9.2. What Hypercode Is Not
+
+* **Not a replacement for typed configuration languages.** CUE, Dhall, Nickel, Pkl, KCL, and Jsonnet are mature at validating and generating configuration *data*, with strong type systems, contracts, and tooling. Hypercode does not compete on those axes today (see §9.8); its subject is an addressable *topology* and the rules that target it, not standalone data.
+* **Not model-driven architecture.** The "executable architecture" lineage (MDA, executable BPMN, TOSCA) expects the model to be complete enough that systems can be derived from it mechanically; in practice the models grew as complex as the code, and round-trip synchronization failed. A `.hc` file is deliberately *incomplete*: a skeleton plus context policies, with algorithmic detail left to host code or to a generator.
+* **Not a natural-language specification format.** AGENTS.md, Kiro specs, and GitHub Spec Kit guide coding agents with Markdown. Hypercode is positioned *underneath* such documents: the part of a specification that must resolve deterministically, diff semantically, and carry provenance.
+* **Not an interface contract or agent protocol.** OpenAPI, AsyncAPI, and GraphQL describe service boundaries; MCP and A2A standardize agent interoperability. Hypercode nodes may *reference* such contracts as properties. Generating or replacing them is an explicit non-goal: pulling interface schemas into `.hcs` would recreate the completeness pressure that bloated MDA models.
+
+### 9.3. Prior Art Map
+
+| Segment | Representative tools | What they solve | Relation to Hypercode |
+|---|---|---|---|
+| Typed configuration languages | CUE, Dhall, Nickel, Pkl, KCL, Jsonnet | validation, schemas, DRY configuration generation | Hypercode adds an addressable topology with cascade and provenance semantics; it does not yet match their type systems |
+| Deployment overlays | Helm, Kustomize, kpt | packaging and per-environment overlays for Kubernetes manifests | the same pain (multi-environment duplication), but overlays target manifests, and "why is this value here?" is answered by archaeology; Hypercode makes provenance part of resolution semantics |
+| Application models | OAM / KubeVela | separating developer components from operator traits and policies over an application topology | the closest structural analog — a two-artifact split over an application topology; OAM is Kubernetes-specific and has no specificity cascade, no property-level provenance, and no codegen-oriented IR |
+| DI / wiring | Spring, Guice, Dagger | object-graph wiring, including compile-time code generation | declarative composition roots and AOT wiring are not new; Hypercode adds context resolution, provenance, and stable language-agnostic anchors |
+| Architecture as code | Structurizr / C4, TOSCA, BPMN | modeling, documentation, orchestration | these model or document systems; Hypercode aims at a codegen-ready resolved IR with provenance |
+| Interface contracts | OpenAPI, AsyncAPI, GraphQL | service-boundary contracts | adjacent layers: Hypercode nodes reference these contracts; generating them is a non-goal (§9.2) |
+| Agent protocols & instructions | MCP, A2A, AGENTS.md | agent interoperability; coding-agent guidance | orthogonal; Hypercode can be the formal artifact such agents consume |
+| AI spec-driven development | GitHub Spec Kit, Kiro | natural-language specifications as the source of truth for code generation | shared thesis ("code as regenerated output"); Hypercode contributes the formally resolvable, diffable, provenance-carrying layer that Markdown cannot provide |
+| Software product lines (academic) | feature models (FODA), delta-oriented programming, CVL | one structure, many variants | white-label contexts are a product-line scenario; to our knowledge, cascade-with-specificity over context dimensions has not been explored as a variability mechanism in that literature |
+
+### 9.4. Why Cascade — the Override Objection
+
+The strongest objection to Hypercode's design comes from the configuration-language community itself. Drawing on Google's experience with GCL — where inheritance and overrides became a chronic source of configuration bugs — the designers of CUE made unification order-independent and *forbade* overrides entirely: in CUE, the origin of a value is never in doubt precisely because no rule can silently replace another. Hypercode deliberately reintroduces overriding, so the choice requires a defense. It has four parts:
+
+1. **Determinism is machine-checked, not promised.** Cascade resolution (specificity, then source order) is specified operationally ([resolution semantics](../EBNF/Hypercode_Resolution.md)) and cross-checked by an executable [Lean 4 oracle](../SPEC/lean/). Resolution never depends on evaluation order.
+2. **Provenance is core semantics, not optional tooling.** Every resolved property records its winning selector and source location as part of the [IR contract](../Schema/hypercode-ir-v1.schema.json), not as an add-on. The CSS cascade became manageable the day developer tools showed where each style came from; Hypercode bakes that affordance into the format. A planned `hypercode explain` command will surface the full match trace, including losing rules.
+3. **Values cascade; contracts only narrow.** The planned contract layer (property schemas attached via selectors) is monotonic in CUE's spirit: a more specific rule may override a *value*, but may only tighten — never weaken — a *contract* established by a less specific rule. Behavior cascades; safety does not. This asymmetry is the design's direct answer to the GCL lesson.
+4. **Known failure modes are acknowledged.** Specificity wars and selector escalation are real CSS pathologies at scale. Countermeasures — origin/layer control analogous to CSS `@layer`, dangling-selector validation (already in `hypercode validate`), and explain tooling — are sequenced in the [work plan](../workplan.md) ahead of language surface that would amplify them.
+
+### 9.5. Why a Stable Topology
+
+Selector rules need something stable to address. `.hc` exists to provide exactly that: a small, versioned, addressable graph whose nodes (`type`, `.class`, `#id`) act as anchors. Those anchors serve every downstream consumer at once: `.hcs` rules target them, generated code can be tagged with the node it implements, validators map findings back to them, and diffs of the resolved graph identify affected modules. Without a stable topology, provenance, semantic diffing, and incremental regeneration lose their reference frame — which is why the structure is a separate artifact rather than keys scattered through configuration data.
+
+### 9.6. Why Provenance
+
+In layered configuration systems the recurring operational question is "where did this value come from?", and it is answered by archaeology across charts, overlays, and profiles. Hypercode's resolver answers it as part of its output: every resolved property carries the selector and source line that won the cascade. Provenance turns the specification from text into an audit and debugging artifact. For AI-assisted generation it does further work: a validator that finds nonconforming generated code can state which rule demanded the behavior, and generated tests can carry their provenance as comments — making the cascade an auditable trail rather than an opaque merge.
+
+### 9.7. Why AI Code Generation
+
+Spec-driven development is converging on the view that the specification is the durable artifact and code is increasingly a regenerated output. Today that movement runs almost entirely on natural-language Markdown, which neither resolves deterministically nor diffs semantically. Hypercode's intended role is the formal substrate underneath it, with three consequences:
+
+* **Confined nondeterminism.** The specification side resolves deterministically (machine-checked, §9.4); nondeterminism is confined to the generation step, where it can be validated against the resolved graph.
+* **A fixed generated/durable boundary.** Classic MDA demanded complete models; an LLM generator tolerates incompleteness, so `.hc` can stay a skeleton. The node boundary fixes the division of labor: orchestration and wiring are derived from the resolved graph (mechanically where possible), while durable leaf implementations live behind generated interfaces and are never overwritten. Node-level hashes over the resolved IR provide the invalidation signal for incremental regeneration.
+* **Review compression.** The unit of human review shifts from generated code to the specification diff: humans approve a small, formally resolved change; machines expand it into code and validate the expansion against the same graph.
+
+### 9.8. Acknowledged Limits
+
+* **Context is resolve-time.** `--ctx` is supplied when resolving; dynamic per-request context (e.g., a single deployment serving many tenants) would require embedding the resolver as a runtime library and is currently out of scope.
+* **No integrity chain yet.** As noted in §8, nothing verifies the provenance chain end-to-end (specification hash → IR hash → generated-code attestation). For the review-compression story to carry governance weight, such attestations are eventually required; they are deliberately deferred.
+* **Type-system maturity.** Resolved values are untyped strings in IR v1, and the contract layer (§9.4) is planned, not implemented. Until both land (an IR v2 concern), Hypercode does not compete with typed configuration languages on safety.
 
 ## 10. Open Questions
 
@@ -256,7 +312,23 @@ The specification assumes that the resolution and execution engine is trusted. N
 * [Spring Framework: Dependency Injection](https://docs.spring.io/spring-framework/reference/core/beans/)
 * [Terraform Configuration Language](https://developer.hashicorp.com/terraform/language)
 
+Prior art surveyed in §9:
+
+* [CUE](https://cuelang.org/) · [Pkl](https://pkl-lang.org/) · [Dhall](https://dhall-lang.org/) · [Nickel](https://nickel-lang.org/) · [KCL](https://www.kcl-lang.io/) · [Jsonnet](https://jsonnet.org/) — typed configuration languages
+* [Helm](https://helm.sh/) · [Kustomize](https://kustomize.io/) — deployment overlays
+* [Open Application Model](https://oam.dev/) · [KubeVela](https://kubevela.io/) — application models
+* [Structurizr DSL](https://docs.structurizr.com/dsl) · [OASIS TOSCA](https://www.oasis-open.org/committees/tosca/) · [OMG BPMN](https://www.omg.org/spec/BPMN/) — architecture as code
+* [OpenAPI](https://www.openapis.org/) · [AsyncAPI](https://www.asyncapi.com/) — interface contracts
+* [Model Context Protocol](https://modelcontextprotocol.io/) · [A2A](https://a2a-protocol.org/) · [AGENTS.md](https://agents.md/) — agent protocols & instructions
+* [GitHub Spec Kit](https://github.com/github/spec-kit) · [Kiro](https://kiro.dev/) · [Martin Fowler — Exploring Gen AI / spec-driven development](https://martinfowler.com/articles/exploring-gen-ai.html) — AI spec-driven development
+* Kang et al., *Feature-Oriented Domain Analysis (FODA)*, CMU/SEI-90-TR-021, 1990 · Pohl, Böckle & van der Linden, *Software Product Line Engineering*, Springer, 2005 — software product lines
+
 ## 12. Change Log
+
+**Version 0.2** (2026-06-10):
+
+* Replaced §9 "Comparison to Existing Concepts" with "Novelty and Prior Art": the novelty claim stated as a falsifiable combination; non-goals; a prior-art map (typed configuration languages, deployment overlays, OAM/KubeVela, DI, architecture-as-code, interface contracts, agent protocols, AI spec-driven development, software product lines); the override objection and its answer, including the *values cascade, contracts only narrow* rule; rationale for stable topology, provenance, and AI code generation; acknowledged limits.
+* Extended §11 References with the surveyed prior art.
 
 **Version 0.1** (2025-07-12):
 

--- a/RFC/Hypercode.md
+++ b/RFC/Hypercode.md
@@ -263,6 +263,7 @@ Hypercode is therefore a new *combination* and a new *layer* — a context-resol
 | DI / wiring | Spring, Guice, Dagger | object-graph wiring, including compile-time code generation | declarative composition roots and AOT wiring are not new; Hypercode adds context resolution, provenance, and stable language-agnostic anchors |
 | Architecture as code | Structurizr / C4, TOSCA, BPMN | modeling, documentation, orchestration | these model or document systems; Hypercode aims at a codegen-ready resolved IR with provenance |
 | Interface contracts | OpenAPI, AsyncAPI, GraphQL | service-boundary contracts | adjacent layers: Hypercode nodes reference these contracts; generating them is a non-goal (§9.2) |
+| Runtime feature flags | OpenFeature, LaunchDarkly | dynamic, per-request flag evaluation against runtime contexts | a different binding time: flags decide values at runtime, Hypercode resolves at build/generation time into an IR (§9.8); the layers compose rather than compete |
 | Agent protocols & instructions | MCP, A2A, AGENTS.md | agent interoperability; coding-agent guidance | orthogonal; Hypercode can be the formal artifact such agents consume |
 | AI spec-driven development | GitHub Spec Kit, Kiro | natural-language specifications as the source of truth for code generation | shared thesis ("code as regenerated output"); Hypercode contributes the formally resolvable, diffable, provenance-carrying layer that Markdown cannot provide |
 | Software product lines (academic) | feature models (FODA), delta-oriented programming, CVL | one structure, many variants | white-label contexts are a product-line scenario; to our knowledge, cascade-with-specificity over context dimensions has not been explored as a variability mechanism in that literature |
@@ -273,7 +274,12 @@ The strongest objection to Hypercode's design comes from the configuration-langu
 
 1. **Determinism is machine-checked, not promised.** Cascade resolution (specificity, then source order) is specified operationally ([resolution semantics](../EBNF/Hypercode_Resolution.md)) and cross-checked by an executable [Lean 4 oracle](../SPEC/lean/). Resolution never depends on evaluation order.
 2. **Provenance is core semantics, not optional tooling.** Every resolved property records its winning selector and source location as part of the [IR contract](../Schema/hypercode-ir-v1.schema.json), not as an add-on. The CSS cascade became manageable the day developer tools showed where each style came from; Hypercode bakes that affordance into the format. A planned `hypercode explain` command will surface the full match trace, including losing rules.
-3. **Values cascade; contracts only narrow.** The planned contract layer (property schemas attached via selectors) is monotonic in CUE's spirit: a more specific rule may override a *value*, but may only tighten — never weaken — a *contract* established by a less specific rule. Behavior cascades; safety does not. This asymmetry is the design's direct answer to the GCL lesson.
+3. **Values cascade; contracts only narrow.** The planned contract layer (property schemas attached via selectors) is monotonic in CUE's spirit. Although that layer is not yet implemented, its governing rule is fixed normatively now:
+
+   > A more specific selector **MAY** override a value.
+   > A more specific selector **MUST NOT** weaken a contract established by a less specific rule; weakening is a resolution error.
+
+   For example, given a base contract `Database: pool_size: int >= 1`, a more specific `Database#main: pool_size: int >= 10` is valid (narrowing), while `Database#main: pool_size: int >= 0` is rejected (weakening). Behavior cascades; safety does not. This asymmetry is the design's direct answer to the GCL lesson.
 4. **Known failure modes are acknowledged.** Specificity wars and selector escalation are real CSS pathologies at scale. Countermeasures — origin/layer control analogous to CSS `@layer`, dangling-selector validation (already in `hypercode validate`), and explain tooling — are sequenced in the [work plan](../workplan.md) ahead of language surface that would amplify them.
 
 ### 9.5. Why a Stable Topology
@@ -294,8 +300,8 @@ Spec-driven development is converging on the view that the specification is the 
 
 ### 9.8. Acknowledged Limits
 
-* **Context is resolve-time.** `--ctx` is supplied when resolving; dynamic per-request context (e.g., a single deployment serving many tenants) would require embedding the resolver as a runtime library and is currently out of scope.
-* **No integrity chain yet.** As noted in §8, nothing verifies the provenance chain end-to-end (specification hash → IR hash → generated-code attestation). For the review-compression story to carry governance weight, such attestations are eventually required; they are deliberately deferred.
+* **Context binds at resolve time.** `--ctx` is supplied when resolving: Hypercode's default mode decides context at build/generation time. Runtime feature-flag systems (OpenFeature, LaunchDarkly) decide flag values per request at runtime — a different layer that composes with Hypercode rather than competing with it. Serving dynamic context from a single deployment (e.g., many tenants per process) would require embedding the resolver as a runtime library; that optional mode raises its own caching, latency, and provenance questions and is currently out of scope.
+* **No integrity chain yet.** As noted in §8, nothing verifies the chain end-to-end: signed `.hc`/`.hcs` → resolved-IR hash → generator identity and version → generated-artifact hashes → validator report. SLSA provides the reference vocabulary for such attestations. For the review-compression story to carry governance weight they are eventually required; they are deliberately deferred as future work.
 * **Type-system maturity.** Resolved values are untyped strings in IR v1, and the contract layer (§9.4) is planned, not implemented. Until both land (an IR v2 concern), Hypercode does not compete with typed configuration languages on safety.
 
 ## 10. Open Questions
@@ -320,7 +326,9 @@ Prior art surveyed in §9:
 * [Structurizr DSL](https://docs.structurizr.com/dsl) · [OASIS TOSCA](https://www.oasis-open.org/committees/tosca/) · [OMG BPMN](https://www.omg.org/spec/BPMN/) — architecture as code
 * [OpenAPI](https://www.openapis.org/) · [AsyncAPI](https://www.asyncapi.com/) — interface contracts
 * [Model Context Protocol](https://modelcontextprotocol.io/) · [A2A](https://a2a-protocol.org/) · [AGENTS.md](https://agents.md/) — agent protocols & instructions
+* [OpenFeature](https://openfeature.dev/) · [LaunchDarkly](https://launchdarkly.com/) — runtime feature flags
 * [GitHub Spec Kit](https://github.com/github/spec-kit) · [Kiro](https://kiro.dev/) · [Martin Fowler — Exploring Gen AI / spec-driven development](https://martinfowler.com/articles/exploring-gen-ai.html) — AI spec-driven development
+* [SLSA](https://slsa.dev/) — supply-chain attestation vocabulary (deferred integrity work, §9.8)
 * Kang et al., *Feature-Oriented Domain Analysis (FODA)*, CMU/SEI-90-TR-021, 1990 · Pohl, Böckle & van der Linden, *Software Product Line Engineering*, Springer, 2005 — software product lines
 
 ## 12. Change Log
@@ -329,6 +337,9 @@ Prior art surveyed in §9:
 
 * Replaced §9 "Comparison to Existing Concepts" with "Novelty and Prior Art": the novelty claim stated as a falsifiable combination; non-goals; a prior-art map (typed configuration languages, deployment overlays, OAM/KubeVela, DI, architecture-as-code, interface contracts, agent protocols, AI spec-driven development, software product lines); the override objection and its answer, including the *values cascade, contracts only narrow* rule; rationale for stable topology, provenance, and AI code generation; acknowledged limits.
 * Extended §11 References with the surveyed prior art.
+* Stated the cascade-safety rule normatively (§9.4): a more specific selector MAY override a value, MUST NOT weaken an inherited contract.
+* Drew the runtime boundary (§9.3, §9.8): build/generation-time resolution by default vs. runtime feature flags (OpenFeature, LaunchDarkly); embedded runtime resolution noted as an optional, out-of-scope mode.
+* Named SLSA as the reference vocabulary for the deferred integrity/attestation chain (§9.8).
 
 **Version 0.1** (2025-07-12):
 

--- a/RFC/Hypercode.md
+++ b/RFC/Hypercode.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 
-**Version:** 0.2
+**Version:** 0.1.1
 
 **Date:** June 10, 2026
 
@@ -333,7 +333,7 @@ Prior art surveyed in §9:
 
 ## 12. Change Log
 
-**Version 0.2** (2026-06-10):
+**Version 0.1.1** (2026-06-10):
 
 * Replaced §9 "Comparison to Existing Concepts" with "Novelty and Prior Art": the novelty claim stated as a falsifiable combination; non-goals; a prior-art map (typed configuration languages, deployment overlays, OAM/KubeVela, DI, architecture-as-code, interface contracts, agent protocols, AI spec-driven development, software product lines); the override objection and its answer, including the *values cascade, contracts only narrow* rule; rationale for stable topology, provenance, and AI code generation; acknowledged limits.
 * Extended §11 References with the surveyed prior art.

--- a/RFC/Hypercode.md
+++ b/RFC/Hypercode.md
@@ -214,7 +214,7 @@ APIServer > Listen:
  *  Runs the same app, but it now uses a PostgreSQL database and logs in JSON format. The core logic in `app.hc` remains untouched:
 
  ```bash
- hypercode-runner app.hc --hcs config.hcs --env production
+ hypercode-runner app.hc --hcs config.hcs --ctx env=production
  ```
 
  ## 6. Compatibility and Interoperability
@@ -272,8 +272,8 @@ Hypercode is therefore a new *combination* and a new *layer* — a context-resol
 
 The strongest objection to Hypercode's design comes from the configuration-language community itself. Drawing on Google's experience with GCL — where inheritance and overrides became a chronic source of configuration bugs — the designers of CUE made unification order-independent and *forbade* overrides entirely: in CUE, the origin of a value is never in doubt precisely because no rule can silently replace another. Hypercode deliberately reintroduces overriding, so the choice requires a defense. It has four parts:
 
-1. **Determinism is machine-checked, not promised.** Cascade resolution (specificity, then source order) is specified operationally ([resolution semantics](../EBNF/Hypercode_Resolution.md)) and cross-checked by an executable [Lean 4 oracle](../SPEC/lean/). Resolution never depends on evaluation order.
-2. **Provenance is core semantics, not optional tooling.** Every resolved property records its winning selector and source location as part of the [IR contract](../Schema/hypercode-ir-v1.schema.json), not as an add-on. The CSS cascade became manageable the day developer tools showed where each style came from; Hypercode bakes that affordance into the format. A planned `hypercode explain` command will surface the full match trace, including losing rules.
+1. **Determinism is machine-checked, not promised.** Cascade resolution (specificity, then source order) is specified operationally ([resolution semantics](../EBNF/Hypercode_Resolution.md)) and cross-checked by an executable [Lean 4 oracle](../SPEC/lean/). Resolution is independent of rule application and traversal order: the outcome is fully determined by the pair (specificity, source order).
+2. **Provenance is core semantics, not optional tooling.** Every resolved property records its winning selector and source line as part of the [IR contract](../Schema/hypercode-ir-v1.schema.json), not as an add-on. The CSS cascade became manageable the day developer tools showed where each style came from; Hypercode bakes that affordance into the format. A planned `hypercode explain` command will surface the full match trace, including losing rules.
 3. **Values cascade; contracts only narrow.** The planned contract layer (property schemas attached via selectors) is monotonic in CUE's spirit. Although that layer is not yet implemented, its governing rule is fixed normatively now:
 
    > A more specific selector **MAY** override a value.
@@ -295,7 +295,7 @@ In layered configuration systems the recurring operational question is "where di
 Spec-driven development is converging on the view that the specification is the durable artifact and code is increasingly a regenerated output. Today that movement runs almost entirely on natural-language Markdown, which neither resolves deterministically nor diffs semantically. Hypercode's intended role is the formal substrate underneath it, with three consequences:
 
 * **Confined nondeterminism.** The specification side resolves deterministically (machine-checked, §9.4); nondeterminism is confined to the generation step, where it can be validated against the resolved graph.
-* **A fixed generated/durable boundary.** Classic MDA demanded complete models; an LLM generator tolerates incompleteness, so `.hc` can stay a skeleton. The node boundary fixes the division of labor: orchestration and wiring are derived from the resolved graph (mechanically where possible), while durable leaf implementations live behind generated interfaces and are never overwritten. Node-level hashes over the resolved IR provide the invalidation signal for incremental regeneration.
+* **A fixed generated/durable boundary.** Classic MDA demanded complete models; an LLM generator tolerates incompleteness, so `.hc` can stay a skeleton. The node boundary fixes the division of labor: orchestration and wiring are derived from the resolved graph (mechanically where possible), while durable leaf implementations live behind generated interfaces and are never overwritten. Node-level hashes over the resolved IR — a planned `hypercode.ir/v2` addition (see the [work plan](../workplan.md)), not part of IR v1 — will provide the invalidation signal for incremental regeneration.
 * **Review compression.** The unit of human review shifts from generated code to the specification diff: humans approve a small, formally resolved change; machines expand it into code and validate the expansion against the same graph.
 
 ### 9.8. Acknowledged Limits

--- a/workplan.md
+++ b/workplan.md
@@ -20,6 +20,9 @@ cascade sheets (`.hcs`). Companion to the [RFC](RFC/Hypercode.md) and the
 - Rules are **executable specifications** (SpecificationCore): grammar,
   validation and cascade resolution are composable `Specification` /
   `DecisionSpec` objects — the 0AL house style.
+- **Values cascade; contracts accumulate and narrow** (RFC §9.4). A more
+  specific selector may override a value, never weaken an inherited contract —
+  safety is not subject to specificity.
 
 ## Open decisions
 
@@ -84,6 +87,25 @@ cascade sheets (`.hcs`). Companion to the [RFC](RFC/Hypercode.md) and the
 - [x] HC-103 Completion (type/class/id from AST, `.` and `#` triggers) + hover (Markdown: type/class/id/children) — `LSPServer.swift`
 
 *(Aim straight for LSP — the standard for VS Code & editor-agnostic. Hyperprompt's custom CLI+JSON-RPC was a documented MVP stopgap; see its ADR-001.)*
+
+## M8 — Spec-layer hardening (RFC v0.2 §9 follow-through)
+
+P0 — what makes the novelty claim defensible:
+- ⬜ HC-110 `hypercode explain <node>.<property> [--ctx …]` — full cascade trace: winner *and* losing rules with specificity/source-order, contract checks; requires the resolver to retain the matched-rule list (today only the winner survives into the IR)
+- ⬜ HC-111 Monotonic selector contracts — property schemas attached via selectors; values cascade, contracts accumulate & narrow; weakening = resolution error (normative rule: RFC §9.4)
+- ⬜ HC-112 `hypercode.ir/v2` (breaking) — typed values (v1 is strings-only), `file` alongside `line`, specificity + source order, losing rules, contract results, per-node and per-document hashes, context echo, resolver name/version — `Schema/`
+
+P1 — built on v2:
+- ⬜ HC-113 `hypercode diff <old.ir> <new.ir>` — affected nodes/properties with reasons (which rule changed), node-hash based; the invalidation signal for incremental (re)generation
+- ⬜ HC-114 Runtime resolver boundary — document default build/generation-time mode vs. optional embedded runtime resolver (per-request context: caching, latency, provenance); decide library API or explicit out-of-scope — RFC §9.8
+- 🅿️ HC-115 OpenFeature bridge for the runtime mode *(only if HC-114 decides "in scope")*
+
+## M9 — Validation & adoption (DOCS/Positioning.md)
+
+- ⬜ HC-120 One deep Kustomize comparison demo — N tenants × M envs; metrics: duplicated structure, time-to-answer "why is this value here?", affected-module precision via IR diff; **must include** an own failure mode (specificity conflict) resolved via `explain`
+- ⬜ HC-121 Dogfooding as the primary adoption path — Hyperprompt / Ontology consume the resolved IR (consumer-side dialects & backends per `DOCS/Dialects.md` / `DOCS/Backends.md`)
+- 🅿️ HC-122 SLSA-like generation attestation chain — signed `.hc`/`.hcs` → IR hash → generator identity/version → artifact hashes → validator report (RFC §8, §9.8)
+- 🅿️ HC-123 Agent Passport / 0AL integration — attestation chain plugs into 0AL's signed-agent model
 
 ## Cross-cutting
 - [x] HC-090 Swift CI workflow (build + test) — `.github/workflows/swift.yml`

--- a/workplan.md
+++ b/workplan.md
@@ -88,7 +88,7 @@ cascade sheets (`.hcs`). Companion to the [RFC](RFC/Hypercode.md) and the
 
 *(Aim straight for LSP — the standard for VS Code & editor-agnostic. Hyperprompt's custom CLI+JSON-RPC was a documented MVP stopgap; see its ADR-001.)*
 
-## M8 — Spec-layer hardening (RFC v0.2 §9 follow-through)
+## M8 — Spec-layer hardening (RFC §9 follow-through)
 
 P0 — what makes the novelty claim defensible:
 - ⬜ HC-110 `hypercode explain <node>.<property> [--ctx …]` — full cascade trace: winner *and* losing rules with specificity/source-order, contract checks; requires the resolver to retain the matched-rule list (today only the winner survives into the IR)


### PR DESCRIPTION
## Summary

Fixes the post-competitor-analysis plan on paper. Three artifacts in one docs PR:

### 1. RFC v0.1.1 — §9 Novelty and Prior Art (replaces "Comparison to Existing Concepts")

- **9.1 The Claim** — novelty stated as a falsifiable *combination* (stable addressable topology + CSS-like selectors + deterministic cascade + property-level provenance + monotonic contracts + resolved-IR diff), explicitly not "nothing like this exists".
- **9.2 What Hypercode Is Not** — not a typed config language, not MDA/"executable architecture", not a Markdown SDD spec, not an interface contract; generating OpenAPI/AsyncAPI named a non-goal.
- **9.3 Prior Art Map** — ten segments, including **OAM/KubeVela** (closest structural analog), **OpenFeature/LaunchDarkly** (runtime binding-time boundary), and **software product lines** (academic anchor).
- **9.4 Why Cascade — the Override Objection** — the GCL→CUE anti-override argument answered: machine-checked determinism (Lean oracle), provenance as core IR semantics, and the **normative cascade-safety rule**: *a more specific selector MAY override a value, MUST NOT weaken an inherited contract* (with narrowing/weakening example); specificity-war pathologies acknowledged with sequenced countermeasures.
- **9.5–9.7** — rationale for stable topology, provenance, and AI code generation (confined nondeterminism, generated/durable boundary at the node, review compression).
- **9.8 Acknowledged Limits** — resolve-time context binding (vs. runtime flags; embedded runtime resolver = optional, out of scope), no integrity chain yet (SLSA as reference vocabulary), untyped IR v1 values pending contracts / IR v2.
- §11 References extended (~24 links, all verified to resolve); §12 changelog; version/date → 0.1.1 / 2026-06-10 (patch bump: prose and forward-looking direction only, no change to the current language model — 0.2 is reserved for the contract layer actually landing).

### 2. DOCS/Positioning.md (new)

Market formula, phrasing discipline for the novelty claim, what-Hypercode-is-not, one-line layer answers ("why not OpenFeature + CUE?", OAM, Spec Kit, the CUE objection), the asymmetric-cascade safety lock, validation strategy (**one deep Kustomize demo** including an own failure mode resolved via `explain`), dogfooding-first adoption path, deprecated/preferred vocabulary table.

### 3. workplan.md — backlog M8/M9 + new guiding invariant

- Invariant: **values cascade; contracts accumulate and narrow**.
- **M8 spec-layer hardening:** HC-110 `hypercode explain` (full cascade trace incl. losing rules) · HC-111 monotonic selector contracts · HC-112 `hypercode.ir/v2` (breaking: typed values, file+specificity+source-order, losing rules, contract results, hashes, context echo) · HC-113 `hypercode diff` · HC-114 runtime resolver boundary · HC-115 OpenFeature bridge (deferred).
- **M9 validation & adoption:** HC-120 Kustomize demo · HC-121 dogfooding via Hyperprompt/Ontology · HC-122 SLSA-like attestation chain (deferred) · HC-123 Agent Passport / 0AL integration (deferred).

README links the positioning doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)