### PR TITLE
feat: substrate for HC-110..112 (TypedValue, Match, losers, file provenance)

### DIFF
--- a/DOCS/Workplan.md
+++ b/DOCS/Workplan.md
@@ -1,0 +1,249 @@
+# HC-110..112 Implementation Plan
+
+Spec-layer hardening: cascade trace (`explain`), monotonic selector contracts, and IR v2.
+Companion to [workplan.md](../workplan.md) M8 task stubs and [RFC §9](../RFC/Hypercode.md).
+
+## Confirmed decisions
+
+| ID | Decision |
+|---|---|
+| D1 | `TypedValue` = union `string/int/double/bool`; inferred at parse time in `CascadeSheetReader.parseProperty` (no new syntax). |
+| D2 | Losers retained inside `ResolvedValue` as `losers: [Match]`; public API, because `explain` and IR v2 both need them. |
+| D3 | `explain` command address: `<selector> [property]` positional (avoids `Node.prop` ambiguity with class selectors). |
+| D4 | SHA-256 without swift-crypto: vendor ~100-line pure-Swift implementation with NIST vectors in `Tests/`. |
+| D5 | `@contract:` block syntax (fits existing outline-reader mechanics, not `@contract Selector:` which needs new grammar). |
+
+## PR sequence
+
+```
+PR-1 substrate  ──▶  PR-2 HC-112 IR v2  ──▶  PR-3 HC-110 explain
+                                          ──▶  PR-4 HC-111 contracts (also needs PR-1+PR-2)
+```
+
+## PR-1 — Substrate (`feat/hc-112-substrate`)
+
+All three features share these foundations; merges first with zero user-visible change.
+
+### TypedValue
+
+New type in `Sources/Hypercode/HCS/`:
+
+```swift
+public enum TypedValue: Equatable, Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+}
+```
+
+Inference order in `parseProperty`: try `Int`, then `Double`, then `true`/`false`, else `.string`.
+
+### Rule gains `file`
+
+```swift
+public struct Rule {
+    // ...existing fields...
+    public let file: String?   // nil = unknown origin (e.g. in-memory tests)
+}
+```
+
+`CascadeSheetReader.read(_:)` → `read(_:file:)` (optional `String?`), passes `file` into each `Rule`.
+Call sites in CLI: pass the `.hcs` path string.
+
+### Match and ResolvedValue
+
+```swift
+public struct Match: Equatable, Sendable {
+    public let value: TypedValue
+    public let selector: Selector
+    public let file: String?
+    public let line: Int
+    public let specificity: Specificity
+    public let order: Int
+}
+
+public struct ResolvedValue: Equatable, Sendable {
+    public let value: TypedValue          // winner's value
+    public let provenance: Provenance     // kept for back-compat (selector + file + line)
+    public let winner: Match
+    public let losers: [Match]            // sorted descending by precedence
+}
+```
+
+`Provenance` gains `file: String?` (nil for legacy in-memory tests).
+
+### PropertyCascade changes
+
+`decide` sorts all candidates descending, returns winner + all others as `losers`.
+Cascade semantics are **unchanged** — only retention of losing matches is added.
+
+### Package bump
+
+`Package.swift` version comment: `0.5.0-dev`.
+
+---
+
+## PR-2 — HC-112 IR v2 (`feat/hc-112-ir-v2`)
+
+Depends on PR-1.
+
+### Schema
+
+New `Schema/hypercode-ir-v2.schema.json`:
+
+```jsonc
+{
+  "version": "hypercode.ir/v2",
+  "context": { /* echo of --ctx flags */ },
+  "resolver": { "name": "hypercode-swift", "version": "0.5.0" },
+  "documentHash": "<sha256-hex>",   // Merkle root of all node hashes
+  "nodes": [{
+    "type": "...", "class": "...", "id": "...",
+    "hash": "<sha256-hex>",          // over stable JSON of type+class?+id?+properties+childHashes
+    "properties": {
+      "key": {
+        "value": <typed scalar>,
+        "winner": { "selector": "...", "file": "...", "line": 42,
+                    "specificity": [0,0,1], "order": 0 },
+        "losers": [ /* same shape */ ],
+        "contracts": []              // filled by PR-4; empty array in v2 base
+      }
+    },
+    "children": [/* recursive */]
+  }]
+}
+```
+
+### CLI
+
+`hypercode emit ... [--ir-version 1|2]` — default v2.
+v1 emitter kept intact for `--ir-version 1`.
+
+### Hashing (D4)
+
+Vendor `Sources/Hypercode/Crypto/SHA256.swift` (~100 lines, FIPS 180-4).
+Test vectors from NIST FIPS 180-4 in `Tests/SHA256Tests.swift`.
+
+Node hash input: deterministic JSON of `{type, class?, id?, properties: {key: value}, childHashes: []}`.
+Document hash: SHA-256 of newline-joined sorted node hashes (BFS order).
+
+### CI
+
+Add `ajv` JSON Schema validation step to `.github/workflows/swift.yml`:
+validates `Examples/` IR output against `Schema/hypercode-ir-v2.schema.json`.
+
+---
+
+## PR-3 — HC-110 `hypercode explain` (`feat/hc-110-explain`)
+
+Depends on PR-1 and PR-2.
+
+### CLI signature
+
+```
+hypercode explain <file.hc> --hcs <file.hcs> [--ctx key=value]... <selector> [property]
+```
+
+`<selector>`: CSS-like string, e.g. `service`, `.primary`, `#auth`, `service > database`.
+`[property]`: optional; if omitted, show all properties for the matched node(s).
+
+### Text output (default)
+
+```
+Node: service > database  (matched 1 node)
+
+  pool_size
+    WINNER  service > database { pool_size: 20 }
+            file: config.hcs  line: 14  specificity: (0,0,2)  order: 1
+    ──────
+    losing  database { pool_size: 10 }
+            file: config.hcs  line: 7   specificity: (0,0,1)  order: 0
+```
+
+### JSON output (`--diagnostics json`)
+
+Array of explain records using the `Diagnostic` envelope shape + a new `trace` key.
+
+### Tests
+
+Golden-file tests against `Examples/service.{hc,hcs}` for:
+- single property explain (dev context)
+- single property explain (production context, different winner)
+- node-level explain (all properties)
+- no-match selector (non-zero exit, message to stderr)
+
+---
+
+## PR-4 — HC-111 Monotonic contracts (`feat/hc-111-contracts`)
+
+Depends on PR-1, PR-2, and PR-3.
+
+### `.hcs` syntax
+
+```hcs
+@contract:
+  service:
+    timeout[?]: int >= 1 <= 300
+  .primary:
+    replicas: int >= 2
+```
+
+`@contract:` is a new outline block (same level as `@dimension[value]`).
+Reader recognises the keyword and routes to `parseContractBlock`.
+
+### Constraint grammar
+
+```
+constraint  = key ["?"] ":" type [">=" number] ["<=" number]
+type        = "string" | "int" | "float" | "bool"
+key         = identifier
+```
+
+`[?]` = optional (property may be absent). Default: required.
+
+### Monotonicity check (HC-111 normative rule)
+
+Given contracts attached to a selector `S` and an inherited contract from ancestor selector `A`
+(where `specificity(S) > specificity(A)`):
+
+- type must be identical (narrowing preserves the type)
+- numeric `[min, max]` interval of `S` must be ⊆ interval of `A`
+- `required` may not become `optional` (reverse: `optional` → `required` is ok)
+
+Violation = `Diagnostic(severity: .error, code: "HC2101", ...)` → exit 1.
+
+### IR v2 `contracts[]`
+
+Each property entry in v2 IR gains:
+```jsonc
+"contracts": [
+  { "selector": "...", "type": "int", "min": 1, "max": 300, "required": true }
+]
+```
+Accumulated (all applicable contracts, sorted by specificity ascending).
+
+### RFC bump
+
+With this PR: RFC `SPEC-VERSION` → 0.2 (contracts are now in the language model).
+Package release: `0.5.0`.
+Update `EBNF/Hypercode_Syntax.md` with `.hcs` contract block grammar.
+
+---
+
+## Files touched per PR
+
+| File | PR-1 | PR-2 | PR-3 | PR-4 |
+|---|---|---|---|---|
+| `Sources/Hypercode/HCS/CascadeSheet.swift` | TypedValue, Match, Rule.file | — | — | Contract types |
+| `Sources/Hypercode/HCS/Resolver.swift` | Provenance.file, losers retained | — | — | contract eval |
+| `Sources/Hypercode/HCS/CascadeSheetReader.swift` | parseProperty types, read(file:) | — | — | @contract: block |
+| `Sources/Hypercode/Emit/Emitter.swift` | TypedValue render | v2 emitter | — | contracts in v2 |
+| `Sources/HypercodeCLI/main.swift` | pass file to reader | --ir-version flag | explain subcommand | — |
+| `Sources/Hypercode/Crypto/SHA256.swift` | — | new | — | — |
+| `Schema/hypercode-ir-v2.schema.json` | — | new | — | contracts field |
+| `Tests/SHA256Tests.swift` | — | new | — | — |
+| `Tests/ExplainTests.swift` | — | — | new | — |
+| `Tests/ContractTests.swift` | — | — | — | new |
+| `RFC/Hypercode.md` | — | — | — | v0.2 bump |
+| `EBNF/Hypercode_Syntax.md` | — | — | — | @contract syntax |

--- a/DOCS/Workplan.md
+++ b/DOCS/Workplan.md
@@ -37,7 +37,9 @@ public enum TypedValue: Equatable, Sendable {
 }
 ```
 
-Inference order in `parseProperty`: try `Int`, then `Double`, then `true`/`false`, else `.string`.
+Inference order in `parseProperty`: quoted scalars are always `.string` (quoting
+forces string); unquoted scalars try `true`/`false`, then `Int`, then `Double`
+(rejected if it contains letters, so `1e5` stays a string), else `.string`.
 
 ### Rule gains `file`
 

--- a/Sources/Hypercode/Emit/Emitter.swift
+++ b/Sources/Hypercode/Emit/Emitter.swift
@@ -42,7 +42,7 @@ public struct Emitter {
         let properties = node.properties.keys.sorted().map { key -> (String, IR) in
             let resolved = node.properties[key]!
             return (key, .object([
-                ("value", .string(resolved.value)),
+                ("value", .string(resolved.value.rawString)),
                 ("from", .string(resolved.provenance.selector.description)),
                 ("line", .int(resolved.provenance.line)),
             ]))

--- a/Sources/Hypercode/HCS/CascadeSheet.swift
+++ b/Sources/Hypercode/HCS/CascadeSheet.swift
@@ -1,3 +1,21 @@
+/// A typed property value inferred at parse time from the raw scalar text.
+public enum TypedValue: Equatable, Sendable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+
+    /// String representation used by the v1 emitter and backward-compatible accessors.
+    public var rawString: String {
+        switch self {
+        case .string(let s): return s
+        case .int(let i): return String(i)
+        case .double(let d): return String(d)
+        case .bool(let b): return b ? "true" : "false"
+        }
+    }
+}
+
 /// A context guard from an `@dimension[value]` block, e.g. `@env[production]`.
 public struct ContextGuard: Equatable, Sendable {
     public let dimension: String
@@ -13,29 +31,43 @@ public struct ContextGuard: Equatable, Sendable {
 /// context guard, and its source order. Specificity is derived from the selector.
 public struct Rule: Equatable, Sendable {
     public let selector: Selector
-    public let properties: [String: String]
+    public let properties: [String: TypedValue]
     /// `nil` for a global rule; otherwise the `@dimension[value]` it lives under.
     public let condition: ContextGuard?
     /// 0-based position in the sheet, used to break specificity ties.
     public let order: Int
     /// 1-based source line of the selector header (for provenance).
     public let line: Int
+    /// Path of the `.hcs` source file, if known.
+    public let file: String?
 
     public init(
         selector: Selector,
-        properties: [String: String],
+        properties: [String: TypedValue],
         condition: ContextGuard?,
         order: Int,
-        line: Int
+        line: Int,
+        file: String? = nil
     ) {
         self.selector = selector
         self.properties = properties
         self.condition = condition
         self.order = order
         self.line = line
+        self.file = file
     }
 
     public var specificity: Specificity { selector.specificity }
+}
+
+/// One rule's contribution to a property in the resolved cascade trace.
+public struct Match: Equatable, Sendable {
+    public let value: TypedValue
+    public let selector: Selector
+    public let file: String?
+    public let line: Int
+    public let specificity: Specificity
+    public let order: Int
 }
 
 /// A parsed `.hcs` cascade sheet: an ordered list of rules.

--- a/Sources/Hypercode/HCS/CascadeSheet.swift
+++ b/Sources/Hypercode/HCS/CascadeSheet.swift
@@ -16,6 +16,12 @@ public enum TypedValue: Equatable, Sendable {
     }
 }
 
+// String interpolation (e.g. the `hypercode resolve` tree rendering) must show
+// the scalar text, not the enum case spelling.
+extension TypedValue: CustomStringConvertible {
+    public var description: String { rawString }
+}
+
 /// A context guard from an `@dimension[value]` block, e.g. `@env[production]`.
 public struct ContextGuard: Equatable, Sendable {
     public let dimension: String

--- a/Sources/Hypercode/HCS/CascadeSheetReader.swift
+++ b/Sources/Hypercode/HCS/CascadeSheetReader.swift
@@ -114,7 +114,12 @@ public struct CascadeSheetReader {
         guard !key.isEmpty else {
             throw HCSError(message: "empty property key", line: node.line.number)
         }
-        return (key, inferType(unquote(split.right)))
+        // Quoting forces string: `zip: "00123"` and `flag: "false"` must stay
+        // strings. Type inference runs only on unquoted scalars.
+        if isQuoted(split.right) {
+            return (key, .string(unquote(split.right)))
+        }
+        return (key, inferType(String(split.right)))
     }
 
     private func inferType(_ s: String) -> TypedValue {
@@ -123,6 +128,10 @@ public struct CascadeSheetReader {
         if let i = Int(s) { return .int(i) }
         if let d = Double(s), !s.contains(where: { $0.isLetter }) { return .double(d) }
         return .string(s)
+    }
+
+    private func isQuoted(_ s: Substring) -> Bool {
+        s.count >= 2 && ((s.first == "\"" && s.last == "\"") || (s.first == "'" && s.last == "'"))
     }
 
     // MARK: - Selectors & guards

--- a/Sources/Hypercode/HCS/CascadeSheetReader.swift
+++ b/Sources/Hypercode/HCS/CascadeSheetReader.swift
@@ -13,7 +13,9 @@ public struct HCSError: Error, Equatable, CustomStringConvertible, Sendable {
 public struct CascadeSheetReader {
     public init() {}
 
-    public func read(_ source: String) throws -> CascadeSheet {
+    /// Parse a `.hcs` source string into a `CascadeSheet`.
+    /// - Parameter file: Optional path of the source file, stored in each `Rule` for provenance.
+    public func read(_ source: String, file: String? = nil) throws -> CascadeSheet {
         let lines: [RawLine] = source
             .split(separator: "\n", omittingEmptySubsequences: false)
             .enumerated()
@@ -32,7 +34,7 @@ public struct CascadeSheetReader {
         var rules: [Rule] = []
         var order = 0
         for node in outline {
-            try interpretTopLevel(node, into: &rules, order: &order)
+            try interpretTopLevel(node, file: file, into: &rules, order: &order)
         }
         return CascadeSheet(rules: rules)
     }
@@ -59,7 +61,7 @@ public struct CascadeSheetReader {
 
     // MARK: - Interpretation
 
-    private func interpretTopLevel(_ node: Outline, into rules: inout [Rule], order: inout Int) throws {
+    private func interpretTopLevel(_ node: Outline, file: String?, into rules: inout [Rule], order: inout Int) throws {
         let content = String(node.line.trimmed)
         if content.hasPrefix("@") {
             guard let split = splitFirstColon(content), split.right.isEmpty else {
@@ -67,16 +69,17 @@ public struct CascadeSheetReader {
             }
             let condition = try parseGuard(String(split.left), line: node.line.number)
             for child in node.children {
-                try interpretRule(child, condition: condition, into: &rules, order: &order)
+                try interpretRule(child, condition: condition, file: file, into: &rules, order: &order)
             }
         } else {
-            try interpretRule(node, condition: nil, into: &rules, order: &order)
+            try interpretRule(node, condition: nil, file: file, into: &rules, order: &order)
         }
     }
 
     private func interpretRule(
         _ node: Outline,
         condition: ContextGuard?,
+        file: String?,
         into rules: inout [Rule],
         order: inout Int
     ) throws {
@@ -86,17 +89,20 @@ public struct CascadeSheetReader {
         }
         let selector = try parseSelector(String(split.left), line: node.line.number)
 
-        var properties: [String: String] = [:]
+        var properties: [String: TypedValue] = [:]
         for child in node.children {
             let property = try parseProperty(child)
             properties[property.key] = property.value
         }
 
-        rules.append(Rule(selector: selector, properties: properties, condition: condition, order: order, line: node.line.number))
+        rules.append(Rule(
+            selector: selector, properties: properties, condition: condition,
+            order: order, line: node.line.number, file: file
+        ))
         order += 1
     }
 
-    private func parseProperty(_ node: Outline) throws -> (key: String, value: String) {
+    private func parseProperty(_ node: Outline) throws -> (key: String, value: TypedValue) {
         guard node.children.isEmpty else {
             throw HCSError(message: "unexpected nested block under a property", line: node.line.number)
         }
@@ -108,7 +114,15 @@ public struct CascadeSheetReader {
         guard !key.isEmpty else {
             throw HCSError(message: "empty property key", line: node.line.number)
         }
-        return (key, unquote(split.right))
+        return (key, inferType(unquote(split.right)))
+    }
+
+    private func inferType(_ s: String) -> TypedValue {
+        if s == "true" { return .bool(true) }
+        if s == "false" { return .bool(false) }
+        if let i = Int(s) { return .int(i) }
+        if let d = Double(s), !s.contains(where: { $0.isLetter }) { return .double(d) }
+        return .string(s)
     }
 
     // MARK: - Selectors & guards

--- a/Sources/Hypercode/HCS/Resolver.swift
+++ b/Sources/Hypercode/HCS/Resolver.swift
@@ -4,25 +4,32 @@ import SpecificationCore
 /// against which `@dimension[value]` guards are evaluated.
 public typealias ResolutionContext = [String: String]
 
-/// Where a resolved value came from: the winning selector and its source line.
+/// Where a resolved value came from: the winning selector, file, and source line.
 public struct Provenance: Equatable, Sendable {
     public let selector: Selector
+    public let file: String?
     public let line: Int
 
-    public init(selector: Selector, line: Int) {
+    public init(selector: Selector, file: String? = nil, line: Int) {
         self.selector = selector
+        self.file = file
         self.line = line
     }
 }
 
-/// A resolved property value with its provenance.
+/// A resolved property value with its cascade winner, all losing matches, and provenance.
 public struct ResolvedValue: Equatable, Sendable {
-    public let value: String
+    public let value: TypedValue
     public let provenance: Provenance
+    public let winner: Match
+    /// Losing candidates sorted descending by (specificity, source order).
+    public let losers: [Match]
 
-    public init(value: String, provenance: Provenance) {
+    public init(value: TypedValue, provenance: Provenance, winner: Match, losers: [Match]) {
         self.value = value
         self.provenance = provenance
+        self.winner = winner
+        self.losers = losers
     }
 }
 
@@ -59,7 +66,7 @@ extension Rule {
 
 /// A single rule's contribution of a value to one property key.
 private struct Contribution {
-    let value: String
+    let value: TypedValue
     let precedence: Precedence
     let provenance: Provenance
 }
@@ -76,16 +83,40 @@ private struct Precedence: Comparable {
 }
 
 /// Decides the winning value for a property from its competing contributions —
-/// the cascade, expressed as a `DecisionSpec`.
+/// the cascade, expressed as a `DecisionSpec`. Retains all losing candidates for
+/// the explain command and IR v2.
 private struct PropertyCascade: DecisionSpec {
     typealias Context = [Contribution]
     typealias Result = ResolvedValue
 
     func decide(_ candidates: [Contribution]) -> ResolvedValue? {
-        guard let winner = candidates.max(by: { $0.precedence < $1.precedence }) else {
-            return nil
+        guard !candidates.isEmpty else { return nil }
+        let sorted = candidates.sorted { $0.precedence > $1.precedence }
+        let w = sorted[0]
+        let winner = Match(
+            value: w.value,
+            selector: w.provenance.selector,
+            file: w.provenance.file,
+            line: w.provenance.line,
+            specificity: w.precedence.specificity,
+            order: w.precedence.order
+        )
+        let losers = sorted.dropFirst().map { c in
+            Match(
+                value: c.value,
+                selector: c.provenance.selector,
+                file: c.provenance.file,
+                line: c.provenance.line,
+                specificity: c.precedence.specificity,
+                order: c.precedence.order
+            )
         }
-        return ResolvedValue(value: winner.value, provenance: winner.provenance)
+        return ResolvedValue(
+            value: w.value,
+            provenance: w.provenance,
+            winner: winner,
+            losers: losers
+        )
     }
 }
 
@@ -112,7 +143,7 @@ public struct Resolver {
         for rule in sheet.rules where rule.isActive(in: context) {
             guard selectorSpec(rule.selector).isSatisfiedBy(nodeContext) else { continue }
             let precedence = Precedence(specificity: rule.specificity, order: rule.order)
-            let provenance = Provenance(selector: rule.selector, line: rule.line)
+            let provenance = Provenance(selector: rule.selector, file: rule.file, line: rule.line)
             for (key, value) in rule.properties {
                 contributions[key, default: []].append(
                     Contribution(value: value, precedence: precedence, provenance: provenance)

--- a/Sources/HypercodeCLI/main.swift
+++ b/Sources/HypercodeCLI/main.swift
@@ -68,7 +68,7 @@ func runResolve(_ args: [String]) throws {
     guard let hcsPath else { fail("error: resolve needs --hcs <file.hcs>\n\n\(usage)", code: 64) }
 
     let forest = try Parser(source: readSource(hcPath)).parse()
-    let sheet = try CascadeSheetReader().read(readSource(hcsPath))
+    let sheet = try CascadeSheetReader().read(readSource(hcsPath), file: hcsPath)
     let resolved = Resolver(sheet: sheet, context: context).resolve(forest)
     print(ResolvedNode.tree(resolved), terminator: "")
 }
@@ -106,7 +106,7 @@ func runValidate(_ args: [String]) throws {
     // .hc diagnostics point at the .hc file; .hcs diagnostics at the .hcs file.
     var located = tagged(validator.validate(forest), file: hcPath)
     if let hcsPath {
-        let sheet = try CascadeSheetReader().read(readSource(hcsPath))
+        let sheet = try CascadeSheetReader().read(readSource(hcsPath), file: hcsPath)
         located += tagged(validator.validate(sheet, against: forest), file: hcsPath)
     }
     switch diagnosticsFormat {
@@ -158,7 +158,7 @@ func runEmit(_ args: [String]) throws {
     guard let hcPath else { fail("error: emit needs a .hc file\n\n\(usage)", code: 64) }
 
     let forest = try Parser(source: readSource(hcPath)).parse()
-    let sheet = try hcsPath.map { try CascadeSheetReader().read(readSource($0)) } ?? CascadeSheet(rules: [])
+    let sheet = try hcsPath.map { p in try CascadeSheetReader().read(readSource(p), file: p) } ?? CascadeSheet(rules: [])
     let resolved = Resolver(sheet: sheet, context: context).resolve(forest)
     print(Emitter().emit(resolved, as: format), terminator: "")
 }

--- a/Tests/HypercodeTests/CascadeResolverTests.swift
+++ b/Tests/HypercodeTests/CascadeResolverTests.swift
@@ -55,34 +55,34 @@ final class CascadeResolverTests: XCTestCase {
         let tree = try resolve()
 
         let logger = try XCTUnwrap(find("Logger", in: tree))
-        XCTAssertEqual(logger.properties["level"]?.value, "debug")   // Logger type
-        XCTAssertEqual(logger.properties["format"]?.value, "text")   // .console class
+        XCTAssertEqual(logger.properties["level"]?.value, .string("debug"))   // Logger type
+        XCTAssertEqual(logger.properties["format"]?.value, .string("text"))   // .console class
 
         let database = try XCTUnwrap(find("Database", in: tree))
-        XCTAssertEqual(database.properties["driver"]?.value, "sqlite")
-        XCTAssertEqual(database.properties["file"]?.value, "dev.sqlite3")
+        XCTAssertEqual(database.properties["driver"]?.value, .string("sqlite"))
+        XCTAssertEqual(database.properties["file"]?.value, .string("dev.sqlite3"))
         XCTAssertNil(database.properties["pool_size"])               // production-only
 
         let listen = try XCTUnwrap(find("Listen", in: tree))
-        XCTAssertEqual(listen.properties["host"]?.value, "127.0.0.1")
-        XCTAssertEqual(listen.properties["port"]?.value, "5000")
+        XCTAssertEqual(listen.properties["host"]?.value, .string("127.0.0.1"))
+        XCTAssertEqual(listen.properties["port"]?.value, .int(5000))
     }
 
     func testProductionResolution() throws {
         let tree = try resolve(env: "production")
 
         let logger = try XCTUnwrap(find("Logger", in: tree))
-        XCTAssertEqual(logger.properties["level"]?.value, "info")    // later source order wins
-        XCTAssertEqual(logger.properties["format"]?.value, "json")
+        XCTAssertEqual(logger.properties["level"]?.value, .string("info"))    // later source order wins
+        XCTAssertEqual(logger.properties["format"]?.value, .string("json"))
 
         let database = try XCTUnwrap(find("Database", in: tree))
-        XCTAssertEqual(database.properties["driver"]?.value, "postgres") // #id beats type
-        XCTAssertEqual(database.properties["pool_size"]?.value, "50")
-        XCTAssertEqual(database.properties["file"]?.value, "dev.sqlite3") // not overridden
+        XCTAssertEqual(database.properties["driver"]?.value, .string("postgres")) // #id beats type
+        XCTAssertEqual(database.properties["pool_size"]?.value, .int(50))
+        XCTAssertEqual(database.properties["file"]?.value, .string("dev.sqlite3")) // not overridden
 
         let listen = try XCTUnwrap(find("Listen", in: tree))
-        XCTAssertEqual(listen.properties["host"]?.value, "0.0.0.0")
-        XCTAssertEqual(listen.properties["port"]?.value, "8080")
+        XCTAssertEqual(listen.properties["host"]?.value, .string("0.0.0.0"))
+        XCTAssertEqual(listen.properties["port"]?.value, .int(8080))
     }
 
     func testProvenanceTracksWinningSelector() throws {
@@ -91,5 +91,17 @@ final class CascadeResolverTests: XCTestCase {
 
         let prod = try XCTUnwrap(find("Database", in: try resolve(env: "production")))
         XCTAssertEqual(prod.properties["driver"]?.provenance.selector, .id("main-db"))
+    }
+
+    func testLosersAreRetained() throws {
+        // In production, driver: "postgres" (#main-db, specificity (1,0,0)) beats
+        // driver: "sqlite" (Database, specificity (0,0,1)). The loser must be retained.
+        let prod = try XCTUnwrap(find("Database", in: try resolve(env: "production")))
+        let driverResolved = try XCTUnwrap(prod.properties["driver"])
+        XCTAssertEqual(driverResolved.winner.value, .string("postgres"))
+        XCTAssertEqual(driverResolved.winner.selector, .id("main-db"))
+        XCTAssertEqual(driverResolved.losers.count, 1)
+        XCTAssertEqual(driverResolved.losers[0].value, .string("sqlite"))
+        XCTAssertEqual(driverResolved.losers[0].selector, .type("Database"))
     }
 }

--- a/Tests/HypercodeTests/HCSReaderTests.swift
+++ b/Tests/HypercodeTests/HCSReaderTests.swift
@@ -18,10 +18,10 @@ final class HCSReaderTests: XCTestCase {
         XCTAssertEqual(sheet.rules.count, 2)
         XCTAssertEqual(sheet.rules[0].selector, .type("Database"))
         XCTAssertNil(sheet.rules[0].condition)
-        XCTAssertEqual(sheet.rules[0].properties["driver"], "sqlite")   // quotes stripped
-        XCTAssertEqual(sheet.rules[0].properties["in_memory"], "true")
+        XCTAssertEqual(sheet.rules[0].properties["driver"], .string("sqlite"))   // quotes stripped
+        XCTAssertEqual(sheet.rules[0].properties["in_memory"], .bool(true))
         XCTAssertEqual(sheet.rules[1].selector, .klass("pooled"))
-        XCTAssertEqual(sheet.rules[1].properties["pool_size"], "20")
+        XCTAssertEqual(sheet.rules[1].properties["pool_size"], .int(20))
     }
 
     func testContextBlockChildAndIdSelectors() throws {
@@ -38,11 +38,11 @@ final class HCSReaderTests: XCTestCase {
         let idRule = sheet.rules[0]
         XCTAssertEqual(idRule.selector, .id("primary-db"))
         XCTAssertEqual(idRule.condition, ContextGuard(dimension: "env", value: "production"))
-        XCTAssertEqual(idRule.properties["host"], "override.db")
+        XCTAssertEqual(idRule.properties["host"], .string("override.db"))
 
         let childRule = sheet.rules[1]
         XCTAssertEqual(childRule.selector, .child(.type("WebServer"), .type("Listen")))
-        XCTAssertEqual(childRule.properties["port"], "80")
+        XCTAssertEqual(childRule.properties["port"], .int(80))
     }
 
     func testInvalidSelectorThrows() {

--- a/Tests/HypercodeTests/HCSReaderTests.swift
+++ b/Tests/HypercodeTests/HCSReaderTests.swift
@@ -62,4 +62,29 @@ final class HCSReaderTests: XCTestCase {
         XCTAssertEqual(sheet.rules[0].selector, .type("Database"))
         XCTAssertEqual(sheet.rules[1].selector, .klass("pooled"))
     }
+
+    func testQuotedScalarsStayStrings() throws {
+        // Quoting forces string — numeric-looking and boolean-looking literals
+        // must not be type-inferred, and leading zeros must survive.
+        let sheet = try read([
+            "Service:",
+            "  zip: \"00123\"",
+            "  flag: 'false'",
+            "  port: 8080",
+            "  active: true",
+        ])
+        let props = sheet.rules[0].properties
+        XCTAssertEqual(props["zip"], .string("00123"))
+        XCTAssertEqual(props["flag"], .string("false"))
+        XCTAssertEqual(props["port"], .int(8080))
+        XCTAssertEqual(props["active"], .bool(true))
+    }
+
+    func testTypedValueInterpolatesAsScalarText() {
+        // The resolve tree rendering interpolates values directly; the enum
+        // must print scalar text, not its case spelling.
+        XCTAssertEqual("\(TypedValue.int(5000))", "5000")
+        XCTAssertEqual("\(TypedValue.bool(true))", "true")
+        XCTAssertEqual("\(TypedValue.string("debug"))", "debug")
+    }
 }

--- a/Tests/HypercodeTests/WhiteLabelTests.swift
+++ b/Tests/HypercodeTests/WhiteLabelTests.swift
@@ -33,15 +33,15 @@ final class WhiteLabelTests: XCTestCase {
         let acme = try resolve(client: "acme")
         let globex = try resolve(client: "globex")
 
-        XCTAssertEqual(find("Logo", in: acme)?.properties["asset"]?.value, "logos/acme.svg")
-        XCTAssertEqual(find("Logo", in: globex)?.properties["asset"]?.value, "logos/globex.svg")
-        XCTAssertEqual(find("Api", in: acme)?.properties["base_url"]?.value, "https://api.acme.example")
-        XCTAssertEqual(find("Api", in: globex)?.properties["base_url"]?.value, "https://api.globex.example")
+        XCTAssertEqual(find("Logo", in: acme)?.properties["asset"]?.value, .string("logos/acme.svg"))
+        XCTAssertEqual(find("Logo", in: globex)?.properties["asset"]?.value, .string("logos/globex.svg"))
+        XCTAssertEqual(find("Api", in: acme)?.properties["base_url"]?.value, .string("https://api.acme.example"))
+        XCTAssertEqual(find("Api", in: globex)?.properties["base_url"]?.value, .string("https://api.globex.example"))
     }
 
     func testDefaultsWhenNoClient() throws {
         let base = try resolve(client: nil)
-        XCTAssertEqual(find("Logo", in: base)?.properties["asset"]?.value, "logos/default.svg")
-        XCTAssertEqual(find("Api", in: base)?.properties["base_url"]?.value, "https://api.default.example")
+        XCTAssertEqual(find("Logo", in: base)?.properties["asset"]?.value, .string("logos/default.svg"))
+        XCTAssertEqual(find("Api", in: base)?.properties["base_url"]?.value, .string("https://api.default.example"))
     }
 }


### PR DESCRIPTION
## Summary

- Adds `TypedValue` (string/int/double/bool), inferred at parse time in `CascadeSheetReader`
- `Rule.file` and `Provenance.file` carry the `.hcs` source path for all resolved values
- New `Match` struct captures one rule's full contribution; `PropertyCascade.decide` retains all losing candidates
- `ResolvedValue` gains `winner: Match` and `losers: [Match]` — cascade semantics unchanged
- v1 emitter unaffected (`TypedValue.rawString` preserves string output)

This is the shared foundation for HC-112 IR v2 (typed scalars, Merkle hashes), HC-110 `explain` (loser trace), and HC-111 contracts.
See [DOCS/Workplan.md](DOCS/Workplan.md) for the full 4-PR plan.

## Test plan

- [x] 49 tests green (all existing + new `testLosersAreRetained`)
- [x] `HCSReaderTests` — typed property assertions (`in_memory → .bool(true)`, `pool_size → .int(20)`)
- [x] `CascadeResolverTests` — typed value assertions + loser retention in production context
- [x] `WhiteLabelTests` — typed string comparisons
- [x] `EmitterTests` — v1 string output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)